### PR TITLE
3D working version AL preconditioner

### DIFF
--- a/block_demo.cc
+++ b/block_demo.cc
@@ -21,20 +21,16 @@
 #include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/diagonal_matrix.h>
 #include <deal.II/lac/linear_operator.h>
-#include <deal.II/lac/linear_operator_tools.h>
 #include <deal.II/lac/precondition.h>
 #include <deal.II/lac/solver_cg.h>
 #include <deal.II/lac/solver_gmres.h>
 #include <deal.II/lac/solver_minres.h>
 #include <deal.II/lac/sparse_direct.h>
-#include <deal.II/lac/sparse_matrix.h>
-#include <deal.II/lac/sparsity_pattern.h>
-#include <deal.II/lac/trilinos_sparse_matrix.h>
+#include <deal.II/lac/trilinos_precondition.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/non_matching/coupling.h>
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/numerics/data_out_dof_data.h>
-#include <deal.II/numerics/matrix_tools.h>
 #include <deal.II/numerics/vector_tools.h>
 
 #include <cmath>
@@ -47,11 +43,6 @@
 #include "augmented_lagrangian_preconditioner.h"
 #include "rational_preconditioner.h"
 #include "utilities.h"
-
-#ifdef DEAL_II_WITH_TRILINOS
-#include <Epetra_CrsMatrix.h>
-#include <Epetra_RowMatrixTransposer.h>
-#endif
 
 namespace Step60 {
 using namespace dealii;
@@ -157,7 +148,6 @@ class DistributedLagrangeProblem {
   SparsityPattern coupling_sparsity;
 
   SparseMatrix<double> stiffness_matrix;
-  SparseMatrix<double> stiffness_matrix_copy;
   SparseMatrix<double> mass_matrix;
   SparseMatrix<double> Mass_matrix;
   SparseMatrix<double> mass_matrix_immersed_dg;
@@ -290,7 +280,8 @@ void DistributedLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
   if constexpr (spacedim == 2)
     GridGenerator::hyper_cube(*embedded_grid);
   else if constexpr (spacedim == 3)
-    GridGenerator::hyper_cube(*embedded_grid, -.44, .44, false);
+    GridGenerator::hyper_sphere(*embedded_grid, {0.1, -0.1, 0.1}, 0.24);
+  // GridGenerator::hyper_cube(*embedded_grid, -.44, .44, false);
   embedded_grid->refine_global(parameters.initial_embedded_refinement);
 
   if constexpr (spacedim == 2) {
@@ -462,8 +453,6 @@ void DistributedLagrangeProblem<dim, spacedim>::assemble_system() {
         embedding_rhs_function, embedding_rhs,
         static_cast<const Function<spacedim> *>(nullptr), constraints);
 
-    // stiffness_matrix_copy.copy_from(stiffness_matrix);
-
     MatrixTools::create_mass_matrix(
         *space_dh, QGauss<spacedim>(2 * space_fe->degree + 1), Mass_matrix,
         static_cast<const Function<spacedim> *>(nullptr), constraints);
@@ -509,14 +498,26 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
 
   // // Old way
   if (std::strcmp(parameters.solver.c_str(), "CG") == 0) {
-    SparseDirectUMFPACK K_inv_umfpack;
-    K_inv_umfpack.initialize(stiffness_matrix);
-
     auto K = linear_operator(stiffness_matrix);
+    auto K_inv = identity_operator(K);
+
+    // Depending if we are in 2D or 3D, use a sparse direct solver or not
+    SparseDirectUMFPACK K_inv_umfpack;
+    TrilinosWrappers::PreconditionAMG prec_amg;
+    SolverControl K_inv_control(1000, 1e-12, false, true);
+    SolverCG<Vector<double>> K_inv_cg(K_inv_control);
+    if constexpr (spacedim == 3) {
+      prec_amg.initialize(stiffness_matrix);
+      K_inv = inverse_operator(K, K_inv_cg, prec_amg);
+    } else if constexpr (spacedim == 2) {
+      K_inv_umfpack.initialize(stiffness_matrix);
+      K_inv = linear_operator(K, K_inv_umfpack);
+    } else {
+      Assert(false, ExcNotImplemented());
+    }
+
     auto Ct = linear_operator(coupling_matrix);
     auto C = transpose_operator(Ct);
-
-    auto K_inv = linear_operator(K, K_inv_umfpack);
 
     auto S = C * K_inv * Ct;
     SolverCG<Vector<double>> solver_cg(schur_solver_control);
@@ -986,138 +987,19 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
       inverse_squares(i) = 1. / (mass_matrix_immersed_dg.diag_element(i) *
                                  mass_matrix_immersed_dg.diag_element(i));
 
-    // Create the transpose.
+    TrilinosWrappers::PreconditionAMG amg_prec;  //!
+    // amg_prec.initialize(augmented_block);                           //!
+    build_AMG_augmented_block(*space_dh, coupling_matrix, stiffness_matrix,
+                              coupling_sparsity, inverse_squares, constraints,
+                              gamma, amg_prec);
+    auto prec_for_cg = linear_operator(stiffness_matrix, amg_prec);  //!
 
-    // First, wrap the original matrix in a Trilinos matrix
-    TrilinosWrappers::SparseMatrix coupling_trilinos;
-    SparsityPattern sp;
-    sp.copy_from(coupling_sparsity);
-    coupling_trilinos.reinit(coupling_matrix, 1e-15, true, &sp);
-    auto trilinos_matrix = coupling_trilinos.trilinos_matrix();
-
-    // Now, transpose this matrix through Trilinos
-    Epetra_RowMatrixTransposer transposer(&trilinos_matrix);
-    Epetra_CrsMatrix *transpose_matrix;
-    int err = transposer.CreateTranspose(true, transpose_matrix);
-    AssertThrow(err == 0, ExcMessage("Transpose failure!"));
-#ifdef DEBUG
-    std::cout << "rows original matrix:" << trilinos_matrix.NumGlobalRows()
-              << std::endl;
-    std::cout << "cols original matrix:" << trilinos_matrix.NumGlobalCols()
-              << std::endl;
-    std::cout << "rows:" << transpose_matrix->NumGlobalRows() << std::endl;
-    std::cout << "cols:" << transpose_matrix->NumGlobalCols() << std::endl;
-#endif
-
-    // Now, store the transpose in a deal.II matrix for mat-mat multiplication
-
-    // First, create the sparsity pattern for the transpose
-    DynamicSparsityPattern dsp_coupling_sparsity_transposed;
-    dsp_coupling_sparsity_transposed.reinit(coupling_sparsity.n_cols(),
-                                            coupling_sparsity.n_rows());
-
-    // Loop over the original sparsity pattern
-    for (unsigned int row = 0; row < coupling_sparsity.n_rows(); ++row) {
-      for (dealii::SparsityPattern::iterator it = coupling_sparsity.begin(row);
-           it != coupling_sparsity.end(row); ++it) {
-        unsigned int col = it->column();
-        // Insert the transposed entry
-        dsp_coupling_sparsity_transposed.add(col, row);
-      }
-    }
-    SparsityPattern coupling_sparsity_transposed;
-    coupling_sparsity_transposed.copy_from(dsp_coupling_sparsity_transposed);
-    SparseMatrix<double> coupling_t;
-    coupling_t.reinit(coupling_sparsity_transposed);
-
-    // Now populate the matrix
-    const int num_rows = coupling_t.m();
-    for (int i = 0; i < num_rows; ++i) {
-      int num_entries;
-      double *values;
-      int *indices;
-
-      transpose_matrix->ExtractMyRowView(i, num_entries, values, indices);
-
-      for (int j = 0; j < num_entries; ++j) {
-        coupling_t.set(i, transpose_matrix->GCID(indices[j]), values[j]);
-      }
-    }
-#ifdef DEBUG
-    std::cout << "Populated the transpose matrix" << std::endl;
-#endif
-
-    // Now, perform matmat multiplication
-    SparseMatrix<double> augmented_block, BtWinvB;
-    DynamicSparsityPattern dsp_aux(space_dh->n_dofs(), space_dh->n_dofs());
-    const unsigned int dofs_per_cell = space_fe->n_dofs_per_cell();
-    std::vector<types::global_dof_index> current_dof_indices(dofs_per_cell);
-    dsp_aux.compute_mmult_pattern(coupling_sparsity,
-                                  coupling_sparsity_transposed);
-
-    // Add sparsity from matrix2
-    for (unsigned int row = 0; row < space_dh->n_dofs(); ++row) {
-      for (auto it = stiffness_matrix.begin(row);
-           it != stiffness_matrix.end(row); ++it) {
-        dsp_aux.add(row, it->column());
-      }
-    }
-
-    SparsityPattern sp_aux;
-    sp_aux.copy_from(dsp_aux);
-    BtWinvB.reinit(sp_aux);
-
-    // Check that is the transpose
-
-#ifdef DEBUG
-    for (unsigned int i = 0; i < coupling_matrix.m(); ++i)
-      for (unsigned int j = 0; j < coupling_matrix.n(); ++j) {
-        std::cout << "Entry " << coupling_matrix.el(i, j) << " and "
-                  << coupling_t.el(j, i) << std::endl;
-        Assert((coupling_matrix.el(i, j) - coupling_t.el(j, i) < 1e-14),
-               ExcMessage("Transpose matrix is wrong!"));
-      }
-#endif
-
-    SparseMatrix<double> coupling_matrix_copy;
-    coupling_matrix_copy.reinit(coupling_matrix);
-    coupling_matrix_copy.copy_from(coupling_matrix);
-    // inverse_squares = 1.;
-    coupling_matrix_copy.mmult(BtWinvB, coupling_t, inverse_squares, false);
-#ifdef DEBUG
-    std::cout << "Performed mat-mat multiplication" << std::endl;
-    std::cout << "Rows " << BtWinvB.m() << std::endl;
-    std::cout << "Cols " << BtWinvB.n() << std::endl;
-    std::cout << "Norm" << BtWinvB.l1_norm() << std::endl;
-#endif
-
-    stiffness_matrix_copy.reinit(sp_aux);
-    MatrixTools::create_laplace_matrix(
-        *space_dh, QGauss<spacedim>(2 * space_fe->degree + 1),
-        stiffness_matrix_copy, embedding_rhs_function, embedding_rhs_copy,
-        static_cast<const Function<spacedim> *>(nullptr), constraints);
-
-    augmented_block.reinit(stiffness_matrix_copy);
-    augmented_block.copy_from(stiffness_matrix_copy);
-    augmented_block.add(gamma, BtWinvB);
-
-    TrilinosWrappers::PreconditionAMG amg_prec;                     //!
-    amg_prec.initialize(augmented_block);                           //!
-    auto prec_for_cg = linear_operator(augmented_block, amg_prec);  //!
-    std::cout << "Initialized AMG" << std::endl;
-
-// Print matrices to file to check if one is the transpose of the other
-#ifdef DEBUG
-    coupling_matrix.print_formatted(std::cout);
-    coupling_t.print_formatted(std::cout);
-    inverse_squares.print(std::cout);
-#endif
 #endif
 
     auto invW1 = linear_operator(mass_matrix, M_inv_umfpack);
     auto invW = invW1 * invW1;
-    // auto Aug = K + gamma * Ct * invW * C;
-    auto Aug = linear_operator(augmented_block);
+    auto Aug = K + gamma * Ct * invW * C;
+    // auto Aug = linear_operator(augmented_block);
 
     deallog << "gamma: " << gamma << std::endl;
 
@@ -1140,7 +1022,7 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
     system_rhs_block.block(0).add(1., tmp);  // ! augmented
     system_rhs_block.block(1) = embedded_rhs;
 
-    SolverControl control_lagrangian(6000, 1e-11, false, true);
+    SolverControl control_lagrangian(1000, 1e-4, false, true);
     SolverCG<Vector<double>> solver_lagrangian(control_lagrangian);
 
 #ifdef DEAL_II_WITH_TRILINOS

--- a/utilities.h
+++ b/utilities.h
@@ -1,13 +1,24 @@
 #ifndef utilities_h
 #define utilities_h
 
+#include <deal.II/dofs/dof_handler.h>
+#include <deal.II/lac/affine_constraints.h>
+#include <deal.II/lac/linear_operator_tools.h>
 #include <deal.II/lac/sparse_matrix.h>
 #include <deal.II/lac/sparsity_pattern.h>
 #include <deal.II/lac/utilities.h>
 #include <deal.II/lac/vector.h>
+#include <deal.II/numerics/matrix_tools.h>
 
 #include <exception>
 #include <limits>
+
+#ifdef DEAL_II_WITH_TRILINOS
+#include <Epetra_CrsMatrix.h>
+#include <Epetra_RowMatrixTransposer.h>
+#include <deal.II/lac/trilinos_precondition.h>
+#include <deal.II/lac/trilinos_sparse_matrix.h>
+#endif
 
 using namespace dealii;
 
@@ -34,6 +45,144 @@ double compute_l2_norm_matrix(const SparseMatrix<double>& C,
     std::cout << "Not computed, setting NaN." << std::endl;
     return std::numeric_limits<double>::quiet_NaN();
   }
+}
+
+template <int dim, int spacedim>
+void build_AMG_augmented_block(const DoFHandler<dim, spacedim>& space_dh,
+                               const SparseMatrix<double>& coupling_matrix,
+                               const SparseMatrix<double>& stiffness_matrix,
+                               const SparsityPattern& coupling_sparsity,
+                               const Vector<double>& inverse_squares,
+                               const AffineConstraints<double>& space_constraints,
+                               const double gamma,
+                               TrilinosWrappers::PreconditionAMG& amg_prec) {
+  // Create the transpose.
+
+  // First, wrap the original matrix in a Trilinos matrix
+  TrilinosWrappers::SparseMatrix coupling_trilinos;
+  SparsityPattern sp;
+  sp.copy_from(coupling_sparsity);
+  coupling_trilinos.reinit(coupling_matrix, 1e-15, true, &sp);
+  auto trilinos_matrix = coupling_trilinos.trilinos_matrix();
+
+  // Now, transpose this matrix through Trilinos
+  Epetra_RowMatrixTransposer transposer(&trilinos_matrix);
+  Epetra_CrsMatrix* transpose_matrix;
+  int err = transposer.CreateTranspose(true, transpose_matrix);
+  AssertThrow(err == 0, ExcMessage("Transpose failure!"));
+#ifdef DEBUG
+  std::cout << "rows original matrix:" << trilinos_matrix.NumGlobalRows()
+            << std::endl;
+  std::cout << "cols original matrix:" << trilinos_matrix.NumGlobalCols()
+            << std::endl;
+  std::cout << "rows:" << transpose_matrix->NumGlobalRows() << std::endl;
+  std::cout << "cols:" << transpose_matrix->NumGlobalCols() << std::endl;
+#endif
+
+  // Now, store the transpose in a deal.II matrix for mat-mat multiplication
+
+  // First, create the sparsity pattern for the transpose
+  DynamicSparsityPattern dsp_coupling_sparsity_transposed;
+  dsp_coupling_sparsity_transposed.reinit(coupling_sparsity.n_cols(),
+                                          coupling_sparsity.n_rows());
+
+  // Loop over the original sparsity pattern
+  for (unsigned int row = 0; row < coupling_sparsity.n_rows(); ++row) {
+    for (dealii::SparsityPattern::iterator it = coupling_sparsity.begin(row);
+         it != coupling_sparsity.end(row); ++it) {
+      unsigned int col = it->column();
+      // Insert the transposed entry
+      dsp_coupling_sparsity_transposed.add(col, row);
+    }
+  }
+  SparsityPattern coupling_sparsity_transposed;
+  coupling_sparsity_transposed.copy_from(dsp_coupling_sparsity_transposed);
+  SparseMatrix<double> coupling_t;
+  coupling_t.reinit(coupling_sparsity_transposed);
+
+  // Now populate the matrix
+  const int num_rows = coupling_t.m();
+  for (int i = 0; i < num_rows; ++i) {
+    int num_entries;
+    double* values;
+    int* indices;
+
+    transpose_matrix->ExtractMyRowView(i, num_entries, values, indices);
+
+    for (int j = 0; j < num_entries; ++j) {
+      coupling_t.set(i, transpose_matrix->GCID(indices[j]), values[j]);
+    }
+  }
+#ifdef DEBUG
+  std::cout << "Populated the transpose matrix" << std::endl;
+#endif
+
+  // Now, perform matmat multiplication
+  const auto& space_fe = space_dh.get_fe();
+  SparseMatrix<double> augmented_block, BtWinvB;
+  DynamicSparsityPattern dsp_aux(space_dh.n_dofs(), space_dh.n_dofs());
+  const unsigned int dofs_per_cell = space_fe.n_dofs_per_cell();
+  std::vector<types::global_dof_index> current_dof_indices(dofs_per_cell);
+  dsp_aux.compute_mmult_pattern(coupling_sparsity,
+                                coupling_sparsity_transposed);
+
+  // Add sparsity from matrix2
+  for (unsigned int row = 0; row < space_dh.n_dofs(); ++row) {
+    for (auto it = stiffness_matrix.begin(row); it != stiffness_matrix.end(row);
+         ++it) {
+      dsp_aux.add(row, it->column());
+    }
+  }
+
+  SparsityPattern sp_aux;
+  sp_aux.copy_from(dsp_aux);
+  BtWinvB.reinit(sp_aux);
+
+  // Check that is the transpose
+
+#ifdef DEBUG
+  for (unsigned int i = 0; i < coupling_matrix.m(); ++i)
+    for (unsigned int j = 0; j < coupling_matrix.n(); ++j) {
+      std::cout << "Entry " << coupling_matrix.el(i, j) << " and "
+                << coupling_t.el(j, i) << std::endl;
+      Assert((coupling_matrix.el(i, j) - coupling_t.el(j, i) < 1e-14),
+             ExcMessage("Transpose matrix is wrong!"));
+    }
+#endif
+
+  SparseMatrix<double> coupling_matrix_copy;
+  coupling_matrix_copy.reinit(coupling_matrix);
+  coupling_matrix_copy.copy_from(coupling_matrix);
+  // inverse_squares = 1.;
+  coupling_matrix_copy.mmult(BtWinvB, coupling_t, inverse_squares, false);
+#ifdef DEBUG
+  std::cout << "Performed mat-mat multiplication" << std::endl;
+  std::cout << "Rows " << BtWinvB.m() << std::endl;
+  std::cout << "Cols " << BtWinvB.n() << std::endl;
+  std::cout << "Norm" << BtWinvB.l1_norm() << std::endl;
+#endif
+
+  SparseMatrix<double> stiffness_matrix_copy;
+  stiffness_matrix_copy.reinit(sp_aux);
+  MatrixTools::create_laplace_matrix(
+      space_dh, QGauss<spacedim>(2 * space_fe.degree + 1),
+      stiffness_matrix_copy, static_cast<const Function<spacedim>*>(nullptr),space_constraints);
+
+  augmented_block.reinit(stiffness_matrix_copy);
+  augmented_block.copy_from(stiffness_matrix_copy);
+  augmented_block.add(gamma, BtWinvB);
+
+  //!
+  amg_prec.initialize(augmented_block);                           //!
+  auto prec_for_cg = linear_operator(augmented_block, amg_prec);  //!
+  std::cout << "Initialized AMG" << std::endl;
+
+// Print matrices to file to check if one is the transpose of the other
+#ifdef DEBUG
+  coupling_matrix.print_formatted(std::cout);
+  coupling_t.print_formatted(std::cout);
+  inverse_squares.print(std::cout);
+#endif
 }
 
 #endif


### PR DESCRIPTION
I quickly extended this so that it works in 3D. Here the results with $f=0,g=1$ and a ball immersed in $[-1,1]^3$  (see next figure, on the right a contour plot of $u$) Using $Q_1-Q_1$ and mass lumping for the $W=M^2$ gives growing iteration counts for CG inner block (not reported here, but around 300-400 after few refinement cycles).

With $Q_1-Q_0$ I get the numbers in the next tables: CG inner iterations are increasing but much lower than before. Outer iterations are still good. The tolerance for $A_{\gamma}$ block was quite strict $(10^{-12})$, so I tried relaxing it and everything seems to work nicely. In next tables, TOL_CG_Aug denotes the tolerance used for CG + AMG in that block. @federica-mugnaioni @luca-heltai

| DoF (background+immersed)              | FGMRES (outer) | CG + AMG inner iterations for $A_{\gamma}$, TOL_CG_Aug = 1e-12|
| :---------------- | :------: | ----: |
| 35937 + 64     |   7   | 22 |
| 274625 + 256            |   6   | 35 |
| 2146689 + 1024    |  5   | 50 |
| 16974593 + 4096 |  4   | 70 |

| DoF (background+immersed)              | FGMRES (outer) | CG + AMG inner iterations for $A_{\gamma}$, TOL_CG_Aug = 1e-6|
| :---------------- | :------: | ----: |
| 35937 + 64     |   7   | 22 |
| 274625 + 256            |   6   | 35 |
| 2146689 + 1024    |  5   | 49 |
| 16974593 + 4096 |  4   | 49 |

| DoF (background+immersed)              | FGMRES (outer) | CG + AMG inner iterations for $A_{\gamma}$, TOL_CG_Aug = 1e-4|
| :---------------- | :------: | ----: |
| 35937 + 64     |   7   | 10 |
| 274625 + 256            |  6    | 17 |
| 2146689 + 1024    |  5   | 26 |
| 16974593 + 4096 |  4   | 31 |



![ball_immersed_3D](https://github.com/user-attachments/assets/1beb1199-4c7f-4917-a992-befae38da970)

