### PR TITLE
Operatorial version of AL preconditioner(s)

### DIFF
--- a/elliptic_interface.cc
+++ b/elliptic_interface.cc
@@ -164,6 +164,8 @@ public:
 
   bool use_h_scaled_mass = false;
 
+  bool use_operator_form = false;
+
   bool use_sqrt_2_rule = false;
 
   bool do_sanity_checks = true;
@@ -261,6 +263,8 @@ ProblemParameters<dim>::ProblemParameters()
                   "immersed mass matrix.");
     add_parameter("Use h-scaled mass", use_h_scaled_mass,
                   "Use h-scaled mass matrix instead of its square.");
+    add_parameter("Use operator version", use_operator_form,
+                  "Apply operator form of augmented block.");
     add_parameter("Use sqrt(2)-rule for gamma", use_sqrt_2_rule,
                   "Use sqrt(2)-rule for gamma. It makes sense only for "
                   "modified AL variant.");
@@ -696,7 +700,7 @@ template <int dim> unsigned int EllipticInterfaceDLM<dim>::solve() {
   SparseDirectUMFPACK M_inv_umfpack;
   DiagonalMatrix<Vector<double>> diag_inverse;
   Vector<double> inverse_diag_mass;
-  if (parameters.use_h_scaled_mass) {
+  if (parameters.use_h_scaled_mass || parameters.use_operator_form) {
 
     if (parameters.use_diagonal_inverse) {
       inverse_diag_mass.reinit(mass_matrix_fg.m());
@@ -734,10 +738,10 @@ template <int dim> unsigned int EllipticInterfaceDLM<dim>::solve() {
     }
   }
 
-  // If we use the h_scaled variant, we attach the h-scaling factor to the gamma
-  // parameters.
+  // If we use the h_scaled variant or the operator-like version, we attach the
+  // h-scaling factor to the gamma parameters. Also if we use the operator form.
   double gamma_1, gamma_2;
-  if (parameters.use_h_scaled_mass) {
+  if (parameters.use_h_scaled_mass || parameters.use_operator_form) {
     const double h_immersed = GridTools::maximal_cell_diameter(tria_fg);
 
     gamma_1 = parameters.gamma_AL_background / (h_immersed * h_immersed);
@@ -748,9 +752,61 @@ template <int dim> unsigned int EllipticInterfaceDLM<dim>::solve() {
     gamma_2 = parameters.gamma_AL_immersed;
   }
 
-  // Define augmented blocks. Notice that A22_aug is actually A_omega2 +
-  // gamma_AL_background * Id
-  auto A11_aug = A_omega1 + gamma_1 * Ct * invW * C;
+  // Define augmented blocks
+  auto A11_aug = null_operator(A_omega1);
+  if (parameters.use_operator_form) {
+    TimerOutput::Scope t(computing_timer, "Construction of augmented AL term");
+    // first, we add particles at quadrature points of the coupling matrix,
+    Particles::ParticleHandler<dim> immersed_particle_handler;
+    QGauss<dim> immersed_quadrature(2 * fe_bg.degree + 1);
+
+    // initialize particle handler with particles on the immersed domain
+    ALUtils::initialize_particles<dim, dim, dim>(
+        immersed_particle_handler, dof_handler_bg, dof_handler_fg, mapping,
+        mapping, immersed_quadrature);
+
+    // then, we loop over the particles (and related background cells) to build
+    // the AL term
+    std::vector<types::global_dof_index> background_dof_indices(
+        fe_bg.n_dofs_per_cell());
+
+    FullMatrix<double> local_matrix(fe_bg.n_dofs_per_cell(),
+                                    fe_bg.n_dofs_per_cell());
+
+    auto particle = immersed_particle_handler.begin();
+    while (particle != immersed_particle_handler.end()) {
+      local_matrix = 0;
+      const auto &cell = particle->get_surrounding_cell();
+      const auto &dh_cell =
+          typename DoFHandler<dim>::cell_iterator(*cell, &dof_handler_bg);
+      dh_cell->get_dof_indices(background_dof_indices);
+
+      const auto pic = immersed_particle_handler.particles_in_cell(cell);
+      Assert(pic.begin() == particle, ExcInternalError());
+      for (const auto &p : pic) {
+        const Point<dim> ref_q = p.get_reference_location();
+        const double JxW = p.get_properties()[0];
+
+        for (unsigned int i = 0; i < fe_bg.n_dofs_per_cell(); ++i) {
+          for (unsigned int j = 0; j < fe_bg.n_dofs_per_cell(); ++j) {
+            local_matrix(i, j) += gamma_1                       // gamma*h^{-2}
+                                  * fe_bg.shape_value(i, ref_q) // phi_i
+                                  * fe_bg.shape_value(j, ref_q) // phi_j
+                                  * JxW;                        // JxW
+          }
+        }
+      }
+
+      constraints_bg.distribute_local_to_global(
+          local_matrix, background_dof_indices, stiffness_matrix_bg);
+
+      particle = pic.end();
+    }
+    A11_aug = linear_operator(stiffness_matrix_bg);
+  } else {
+    A11_aug = A_omega1 + gamma_1 * Ct * invW * C;
+  }
+
   auto A22_aug = A_omega2 + gamma_2 * M * invW * M;
   auto A12_aug = -gamma_1 * Ct * invW * M;
   // Next one is just transpose_operator(A12_aug);
@@ -766,14 +822,18 @@ template <int dim> unsigned int EllipticInterfaceDLM<dim>::solve() {
   // The first one is for the augmented (1,1) block, while the second one is for
   // the augmented (2,2) block.
   TrilinosWrappers::PreconditionAMG amg_prec_A11, amg_prec_A22;
-  build_AMG_augmented_block_scalar(dof_handler_bg, coupling_matrix,
-                                   stiffness_matrix_bg, inverse_diag_mass,
-                                   coupling_sparsity, constraints_bg, gamma_1,
-                                   parameters.beta_1, amg_prec_A11);
+  if (parameters.use_operator_form)
+    amg_prec_A11.initialize(stiffness_matrix_bg);
+  else
+    build_AMG_augmented_block_scalar(dof_handler_bg, coupling_matrix,
+                                     stiffness_matrix_bg, inverse_diag_mass,
+                                     coupling_sparsity, constraints_bg, gamma_1,
+                                     parameters.beta_1, amg_prec_A11);
 
   // Initialize AMG prec for the A_2 augmented block
-  if (parameters.use_h_scaled_mass) {
-    // in this case, the augmented A_2 block is A_omega2 + gamma * h^2
+  if (parameters.use_h_scaled_mass == true ||
+      parameters.use_operator_form == true) {
+    // in this case, the augmented A_2 block is A_omega2 + gamma * h^{-2}
     // M
     assemble_subsystem(fe_fg, dof_handler_fg, constraints_fg,
                        stiffness_matrix_fg_plus_scaled_M,
@@ -846,8 +906,8 @@ template <int dim> unsigned int EllipticInterfaceDLM<dim>::solve() {
                           system_rhs_block, preconditioner_AL);
 
     } else {
-      // Check that gamma is not too small. We force also gamma2 to be equal to
-      // gamma.
+      // Check that gamma is not too small. We force also gamma2 to be equal
+      // to gamma if we use the ideal variant.
 
       AssertThrow(
           parameters.gamma_AL_background > 1.,

--- a/immersed_laplace.cc
+++ b/immersed_laplace.cc
@@ -65,11 +65,10 @@ struct ResultsData {
   unsigned int outer_iterations;
 };
 
-template <int dim, int spacedim = dim>
-class DistributedLagrangeProblem {
- public:
+template <int dim, int spacedim = dim> class DistributedLagrangeProblem {
+public:
   class Parameters : public ParameterAcceptor {
-   public:
+  public:
     Parameters();
 
     unsigned int initial_refinement = 4;
@@ -92,6 +91,10 @@ class DistributedLagrangeProblem {
 
     unsigned int verbosity_level = 10;
 
+    bool use_operator_form = false;
+
+    bool use_diagonal_inverse = false;
+
     bool initialized = false;
 
     std::string solver = "CG";
@@ -104,7 +107,7 @@ class DistributedLagrangeProblem {
 
   void set_filename(const std::string &filename);
 
- private:
+private:
   const Parameters &parameters;
 
   void setup_grids_and_dofs();
@@ -212,6 +215,19 @@ DistributedLagrangeProblem<dim, spacedim>::Parameters::Parameters()
   add_parameter("Verbosity level", verbosity_level);
 
   add_parameter("Solver", solver);
+
+  enter_subsection("AL preconditioner");
+  {
+    add_parameter("Use operator version", use_operator_form,
+                  "Assemble the augmented (1,1)-block directly as a matrix. If "
+                  "false, the augmented (1,1)-block is applied as K + gamma * "
+                  "Ct * invW * C.");
+    add_parameter(
+        "Use diagonal inverse", use_diagonal_inverse,
+        "Use diagonal approximation for the inverse (eventually squared) of"
+        " the immersed mass matrix in the AL preconditioner.");
+  }
+  leave_subsection();
 
   parse_parameters_call_back.connect([&]() -> void { initialized = true; });
 }
@@ -326,7 +342,7 @@ void DistributedLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
     space_grid->execute_coarsening_and_refinement();
   }
 
-  if (space_grid->n_cells() < 2e6) {  // do not dump grid when mesh is too fine
+  if (space_grid->n_cells() < 2e6) { // do not dump grid when mesh is too fine
     std::ofstream out_refined("grid-refined.gnuplot");
     GridOut grid_out_refined;
     grid_out_refined.write_gnuplot(*space_grid, out_refined);
@@ -377,9 +393,9 @@ void DistributedLagrangeProblem<dim, spacedim>::setup_embedding_dofs() {
   DynamicSparsityPattern mass_dsp(embedded_dh->n_dofs(), embedded_dh->n_dofs());
   DoFTools::make_sparsity_pattern(*embedded_dh, mass_dsp);
   mass_sparsity.copy_from(mass_dsp);
-  mass_matrix.reinit(mass_sparsity);                // M_immersed
-  mass_matrix_immersed_dg.reinit(mass_sparsity);    // M_immersed_DG
-  embedded_stiffness_matrix.reinit(mass_sparsity);  // A_immersed
+  mass_matrix.reinit(mass_sparsity);               // M_immersed
+  mass_matrix_immersed_dg.reinit(mass_sparsity);   // M_immersed_DG
+  embedded_stiffness_matrix.reinit(mass_sparsity); // A_immersed
 
   DynamicSparsityPattern Mass_dsp(space_dh->n_dofs(), space_dh->n_dofs());
   DoFTools::make_sparsity_pattern(*space_dh, Mass_dsp, constraints);
@@ -628,160 +644,244 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
     SparseDirectUMFPACK M_inv_umfpack;
     M_inv_umfpack.initialize(mass_matrix);
 
-    const double gamma = 10;
+    double gamma = 10;
+    TrilinosWrappers::PreconditionAMG amg_prec;
+    auto prec_for_cg = null_operator(K);
+
     export_to_matlab_csv(stiffness_matrix, "A.csv");
+
+    if (parameters.use_operator_form) {
+
+      const double h_immersed =
+          GridTools::maximal_cell_diameter(*embedded_grid, *embedded_mapping);
+      gamma *= 1. / h_immersed;
+
+      Particles::ParticleHandler<spacedim> immersed_particle_handler;
+      QGauss<dim> immersed_quadrature(2 * space_fe->degree + 1);
+      ALUtils::initialize_particles<spacedim, dim, spacedim>(
+          immersed_particle_handler, *space_dh, *embedded_dh,
+          StaticMappingQ1<spacedim>::mapping, *embedded_mapping,
+          immersed_quadrature);
+
+      // and then we loop over the particles to build the AL term
+      std::vector<types::global_dof_index> background_dof_indices(
+          space_fe->n_dofs_per_cell());
+
+      FullMatrix<double> local_matrix(space_fe->n_dofs_per_cell(),
+                                      space_fe->n_dofs_per_cell());
+
+      auto particle = immersed_particle_handler.begin();
+      while (particle != immersed_particle_handler.end()) {
+        local_matrix = 0;
+        const auto &cell = particle->get_surrounding_cell();
+        const auto &dh_cell =
+            typename DoFHandler<spacedim>::cell_iterator(*cell, space_dh.get());
+        dh_cell->get_dof_indices(background_dof_indices); // background dofs
+
+        const auto pic = immersed_particle_handler.particles_in_cell(cell);
+        Assert(pic.begin() == particle, ExcInternalError());
+        for (const auto &p : pic) {
+          const Point<spacedim> ref_q = p.get_reference_location();
+          const double JxW = p.get_properties()[0];
+
+          for (unsigned int i = 0; i < space_fe->n_dofs_per_cell(); ++i) {
+            for (unsigned int j = 0; j < space_fe->n_dofs_per_cell(); ++j) {
+              local_matrix(i, j) +=
+                  gamma *                           // gamma * h^{-1}
+                  space_fe->shape_value(i, ref_q) * // phi_i(q)
+                  space_fe->shape_value(j, ref_q)   // phi_j(q)
+                  * JxW;
+            }
+          }
+        }
+
+        constraints.distribute_local_to_global(
+            local_matrix, background_dof_indices, stiffness_matrix);
+
+        particle = pic.end();
+      }
+
+      amg_prec.initialize(stiffness_matrix);
+      prec_for_cg = linear_operator(stiffness_matrix, amg_prec);
+
+    } else {
+
 #ifdef DEAL_II_WITH_TRILINOS
 
-    // Construct explicitely vector storing M^{-2}
-    Vector<double> inverse_squares(mass_matrix_immersed_dg.m());  // M^{-2}
-    for (types::global_dof_index i = 0; i < mass_matrix_immersed_dg.m(); ++i)
-      inverse_squares(i) = 1. / (mass_matrix_immersed_dg.diag_element(i) *
-                                 mass_matrix_immersed_dg.diag_element(i));
+      // Construct explicitely vector storing M^{-2}
+      Vector<double> inverse_squares(mass_matrix_immersed_dg.m()); // M^{-2}
+      for (types::global_dof_index i = 0; i < mass_matrix_immersed_dg.m(); ++i)
+        inverse_squares(i) = 1. / (mass_matrix_immersed_dg.diag_element(i) *
+                                   mass_matrix_immersed_dg.diag_element(i));
 
-    // Create the transpose.
+      // Create the transpose.
 
-    // First, wrap the original matrix in a Trilinos matrix
-    TrilinosWrappers::SparseMatrix coupling_trilinos;
-    SparsityPattern sp;
-    sp.copy_from(coupling_sparsity);
-    coupling_trilinos.reinit(coupling_matrix, 1e-15, true, &sp);
-    auto trilinos_matrix = coupling_trilinos.trilinos_matrix();
+      // First, wrap the original matrix in a Trilinos matrix
+      TrilinosWrappers::SparseMatrix coupling_trilinos;
+      SparsityPattern sp;
+      sp.copy_from(coupling_sparsity);
+      coupling_trilinos.reinit(coupling_matrix, 1e-15, true, &sp);
+      auto trilinos_matrix = coupling_trilinos.trilinos_matrix();
 
-    // Now, transpose this matrix through Trilinos
-    Epetra_RowMatrixTransposer transposer(&trilinos_matrix);
-    Epetra_CrsMatrix *transpose_matrix;
-    int err = transposer.CreateTranspose(true, transpose_matrix);
-    AssertThrow(err == 0, ExcMessage("Transpose failure!"));
+      // Now, transpose this matrix through Trilinos
+      Epetra_RowMatrixTransposer transposer(&trilinos_matrix);
+      Epetra_CrsMatrix *transpose_matrix;
+      int err = transposer.CreateTranspose(true, transpose_matrix);
+      AssertThrow(err == 0, ExcMessage("Transpose failure!"));
 #ifdef DEBUG
-    std::cout << "rows original matrix:" << trilinos_matrix.NumGlobalRows()
-              << std::endl;
-    std::cout << "cols original matrix:" << trilinos_matrix.NumGlobalCols()
-              << std::endl;
-    std::cout << "rows:" << transpose_matrix->NumGlobalRows() << std::endl;
-    std::cout << "cols:" << transpose_matrix->NumGlobalCols() << std::endl;
+      std::cout << "rows original matrix:" << trilinos_matrix.NumGlobalRows()
+                << std::endl;
+      std::cout << "cols original matrix:" << trilinos_matrix.NumGlobalCols()
+                << std::endl;
+      std::cout << "rows:" << transpose_matrix->NumGlobalRows() << std::endl;
+      std::cout << "cols:" << transpose_matrix->NumGlobalCols() << std::endl;
 #endif
 
-    // Now, store the transpose in a deal.II matrix for mat-mat multiplication
+      // Now, store the transpose in a deal.II matrix for mat-mat multiplication
 
-    // First, create the sparsity pattern for the transpose
-    DynamicSparsityPattern dsp_coupling_sparsity_transposed;
-    dsp_coupling_sparsity_transposed.reinit(coupling_sparsity.n_cols(),
-                                            coupling_sparsity.n_rows());
+      // First, create the sparsity pattern for the transpose
+      DynamicSparsityPattern dsp_coupling_sparsity_transposed;
+      dsp_coupling_sparsity_transposed.reinit(coupling_sparsity.n_cols(),
+                                              coupling_sparsity.n_rows());
 
-    // Loop over the original sparsity pattern
-    for (unsigned int row = 0; row < coupling_sparsity.n_rows(); ++row) {
-      for (dealii::SparsityPattern::iterator it = coupling_sparsity.begin(row);
-           it != coupling_sparsity.end(row); ++it) {
-        unsigned int col = it->column();
-        // Insert the transposed entry
-        dsp_coupling_sparsity_transposed.add(col, row);
+      // Loop over the original sparsity pattern
+      for (unsigned int row = 0; row < coupling_sparsity.n_rows(); ++row) {
+        for (dealii::SparsityPattern::iterator it =
+                 coupling_sparsity.begin(row);
+             it != coupling_sparsity.end(row); ++it) {
+          unsigned int col = it->column();
+          // Insert the transposed entry
+          dsp_coupling_sparsity_transposed.add(col, row);
+        }
       }
-    }
-    SparsityPattern coupling_sparsity_transposed;
-    coupling_sparsity_transposed.copy_from(dsp_coupling_sparsity_transposed);
-    SparseMatrix<double> coupling_t;
-    coupling_t.reinit(coupling_sparsity_transposed);
+      SparsityPattern coupling_sparsity_transposed;
+      coupling_sparsity_transposed.copy_from(dsp_coupling_sparsity_transposed);
+      SparseMatrix<double> coupling_t;
+      coupling_t.reinit(coupling_sparsity_transposed);
 
-    // Now populate the matrix
-    const int num_rows = coupling_t.m();
-    for (int i = 0; i < num_rows; ++i) {
-      int num_entries;
-      double *values;
-      int *indices;
+      // Now populate the matrix
+      const int num_rows = coupling_t.m();
+      for (int i = 0; i < num_rows; ++i) {
+        int num_entries;
+        double *values;
+        int *indices;
 
-      transpose_matrix->ExtractMyRowView(i, num_entries, values, indices);
+        transpose_matrix->ExtractMyRowView(i, num_entries, values, indices);
 
-      for (int j = 0; j < num_entries; ++j) {
-        coupling_t.set(i, transpose_matrix->GCID(indices[j]), values[j]);
+        for (int j = 0; j < num_entries; ++j) {
+          coupling_t.set(i, transpose_matrix->GCID(indices[j]), values[j]);
+        }
       }
-    }
 #ifdef DEBUG
-    std::cout << "Populated the transpose matrix" << std::endl;
+      std::cout << "Populated the transpose matrix" << std::endl;
 #endif
 
-    // Now, perform matmat multiplication
-    SparseMatrix<double> augmented_block, BtWinvB;
-    DynamicSparsityPattern dsp_aux(space_dh->n_dofs(), space_dh->n_dofs());
-    const unsigned int dofs_per_cell = space_fe->n_dofs_per_cell();
-    std::vector<types::global_dof_index> current_dof_indices(dofs_per_cell);
-    dsp_aux.compute_mmult_pattern(coupling_sparsity,
-                                  coupling_sparsity_transposed);
+      // Now, perform matmat multiplication
+      SparseMatrix<double> augmented_block, BtWinvB;
+      DynamicSparsityPattern dsp_aux(space_dh->n_dofs(), space_dh->n_dofs());
+      const unsigned int dofs_per_cell = space_fe->n_dofs_per_cell();
+      std::vector<types::global_dof_index> current_dof_indices(dofs_per_cell);
+      dsp_aux.compute_mmult_pattern(coupling_sparsity,
+                                    coupling_sparsity_transposed);
 
-    // Add sparsity from matrix2
-    for (unsigned int row = 0; row < space_dh->n_dofs(); ++row) {
-      for (auto it = stiffness_matrix.begin(row);
-           it != stiffness_matrix.end(row); ++it) {
-        dsp_aux.add(row, it->column());
+      // Add sparsity from matrix2
+      for (unsigned int row = 0; row < space_dh->n_dofs(); ++row) {
+        for (auto it = stiffness_matrix.begin(row);
+             it != stiffness_matrix.end(row); ++it) {
+          dsp_aux.add(row, it->column());
+        }
       }
-    }
 
-    SparsityPattern sp_aux;
-    sp_aux.copy_from(dsp_aux);
-    BtWinvB.reinit(sp_aux);
+      SparsityPattern sp_aux;
+      sp_aux.copy_from(dsp_aux);
+      BtWinvB.reinit(sp_aux);
 
-    // Check that is the transpose
+      // Check that is the transpose
 
 #ifdef DEBUG
-    for (unsigned int i = 0; i < coupling_matrix.m(); ++i)
-      for (unsigned int j = 0; j < coupling_matrix.n(); ++j) {
-        std::cout << "Entry " << coupling_matrix.el(i, j) << " and "
-                  << coupling_t.el(j, i) << std::endl;
-        Assert((coupling_matrix.el(i, j) - coupling_t.el(j, i) < 1e-14),
-               ExcMessage("Transpose matrix is wrong!"));
-      }
+      for (unsigned int i = 0; i < coupling_matrix.m(); ++i)
+        for (unsigned int j = 0; j < coupling_matrix.n(); ++j) {
+          std::cout << "Entry " << coupling_matrix.el(i, j) << " and "
+                    << coupling_t.el(j, i) << std::endl;
+          Assert((coupling_matrix.el(i, j) - coupling_t.el(j, i) < 1e-14),
+                 ExcMessage("Transpose matrix is wrong!"));
+        }
 #endif
 
-    SparseMatrix<double> coupling_matrix_copy;
-    coupling_matrix_copy.reinit(coupling_matrix);
-    coupling_matrix_copy.copy_from(coupling_matrix);
-    // inverse_squares = 1.;
-    coupling_matrix_copy.mmult(BtWinvB, coupling_t, inverse_squares, false);
+      SparseMatrix<double> coupling_matrix_copy;
+      coupling_matrix_copy.reinit(coupling_matrix);
+      coupling_matrix_copy.copy_from(coupling_matrix);
+      // inverse_squares = 1.;
+      coupling_matrix_copy.mmult(BtWinvB, coupling_t, inverse_squares, false);
 #ifdef DEBUG
-    std::cout << "Performed mat-mat multiplication" << std::endl;
-    std::cout << "Rows " << BtWinvB.m() << std::endl;
-    std::cout << "Cols " << BtWinvB.n() << std::endl;
-    std::cout << "Norm" << BtWinvB.l1_norm() << std::endl;
+      std::cout << "Performed mat-mat multiplication" << std::endl;
+      std::cout << "Rows " << BtWinvB.m() << std::endl;
+      std::cout << "Cols " << BtWinvB.n() << std::endl;
+      std::cout << "Norm" << BtWinvB.l1_norm() << std::endl;
 #endif
 
-    stiffness_matrix_copy.reinit(sp_aux);
-    MatrixTools::create_laplace_matrix(
-        *space_dh, QGauss<spacedim>(2 * space_fe->degree + 1),
-        stiffness_matrix_copy, embedding_rhs_function, embedding_rhs_copy,
-        static_cast<const Function<spacedim> *>(nullptr), constraints);
+      stiffness_matrix_copy.reinit(sp_aux);
+      MatrixTools::create_laplace_matrix(
+          *space_dh, QGauss<spacedim>(2 * space_fe->degree + 1),
+          stiffness_matrix_copy, embedding_rhs_function, embedding_rhs_copy,
+          static_cast<const Function<spacedim> *>(nullptr), constraints);
 
-    augmented_block.reinit(stiffness_matrix_copy);
-    augmented_block.copy_from(stiffness_matrix_copy);
-    augmented_block.add(gamma, BtWinvB);
+      augmented_block.reinit(stiffness_matrix_copy);
+      augmented_block.copy_from(stiffness_matrix_copy);
+      augmented_block.add(gamma, BtWinvB);
 
-    TrilinosWrappers::PreconditionAMG amg_prec;                     //!
-    amg_prec.initialize(augmented_block);                           //!
-    auto prec_for_cg = linear_operator(augmented_block, amg_prec);  //!
-    std::cout << "Initialized AMG" << std::endl;
+      amg_prec.initialize(augmented_block);                     //!
+      prec_for_cg = linear_operator(augmented_block, amg_prec); //!
+      std::cout << "Initialized AMG" << std::endl;
 
 // Print matrices to file to check if one is the transpose of the other
 #ifdef DEBUG
-    coupling_matrix.print_formatted(std::cout);
-    coupling_t.print_formatted(std::cout);
-    inverse_squares.print(std::cout);
+      coupling_matrix.print_formatted(std::cout);
+      coupling_t.print_formatted(std::cout);
+      inverse_squares.print(std::cout);
 #endif
+      export_to_matlab_csv(augmented_block, "aug.csv");
+#else
+      DEAL_II_NOT_IMPLEMENTED();
 #endif
+    }
 
     // auto invW1 = linear_operator(mass_matrix, M_inv_umfpack);
     // auto invW = invW1 * invW1;
-    Vector<double> inv_squares(mass_matrix.m());
-    for (unsigned int i = 0; i < mass_matrix.m(); ++i)
-      inv_squares[i] =
-          1. / (mass_matrix.diag_element(i) * mass_matrix.diag_element(i));
+    auto invW = null_operator(M);
+    auto invM = null_operator(M);
+    Vector<double> inv_diagonal(mass_matrix.m());
+    DiagonalMatrix<Vector<double>> diag_matrix(inv_diagonal);
+    if (parameters.use_operator_form) {
 
-    DiagonalMatrix<Vector<double>> diag_matrix(inv_squares);
-    auto invW = linear_operator(diag_matrix);
+      if (parameters.use_diagonal_inverse) {
+        for (unsigned int i = 0; i < mass_matrix.m(); ++i)
+          inv_diagonal[i] = 1. / (mass_matrix.diag_element(i));
 
-    // const double h_gamma =
-    //     GridTools::minimal_cell_diameter(*embedded_grid, *embedded_mapping);
-    // std::cout << "h_gamma = " << h_gamma << std::endl;
+        diag_matrix.reinit(inv_diagonal);
+        invW = linear_operator(diag_matrix);
+      } else {
+        invW = linear_operator(mass_matrix, M_inv_umfpack);
+      }
+    } else {
+      // no operator form, we use M^2
+      if (parameters.use_diagonal_inverse) {
+        for (unsigned int i = 0; i < mass_matrix.m(); ++i)
+          inv_diagonal[i] =
+              1. / (mass_matrix.diag_element(i) * mass_matrix.diag_element(i));
+        diag_matrix.reinit(inv_diagonal);
+        invW = linear_operator(diag_matrix);
+      } else {
+        invM = linear_operator(mass_matrix, M_inv_umfpack);
+        invW = invM * invM;
+      }
+    }
 
-    // auto invW = 1. / (h_gamma * h_gamma) * invW1;
-    auto Aug = K + gamma * Ct * invW * C;
+    auto Aug = null_operator(K);
+    if (parameters.use_operator_form)
+      Aug = linear_operator(stiffness_matrix);
+    else
+      Aug = K + gamma * Ct * invW * C;
 
     deallog << "gamma: " << gamma << std::endl;
 
@@ -789,7 +889,7 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
     BlockVector<double> system_rhs_block;
 
     auto AA = block_operator<2, 2, BlockVector<double>>(
-        {{{{Aug, Ct}}, {{C, Zero}}}});  //! Augmented the (1,1) block
+        {{{{Aug, Ct}}, {{C, Zero}}}}); //! Augmented the (1,1) block
     AA.reinit_domain_vector(solution_block, false);
     AA.reinit_range_vector(system_rhs_block, false);
 
@@ -801,7 +901,7 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
     tmp.reinit(embedding_rhs.size());
     tmp = gamma * Ct * invW * embedded_rhs;
     system_rhs_block.block(0) = embedding_rhs;
-    system_rhs_block.block(0).add(1., tmp);  // ! augmented
+    system_rhs_block.block(0).add(1., tmp); // ! augmented
     system_rhs_block.block(1) = embedded_rhs;
 
     SolverControl control_lagrangian(100, 1e-2, false, true);
@@ -809,10 +909,10 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
 
 #ifdef DEAL_II_WITH_TRILINOS
     auto Aug_inv =
-        inverse_operator(Aug, solver_lagrangian, prec_for_cg);  //! augmented
+        inverse_operator(Aug, solver_lagrangian, prec_for_cg); //! augmented
 #else
     auto Aug_inv = inverse_operator(Aug, solver_lagrangian,
-                                    PreconditionIdentity());  //! augmented
+                                    PreconditionIdentity()); //! augmented
 #endif
     SolverFGMRES<BlockVector<double>> solver_fgmres(schur_solver_control);
 
@@ -820,10 +920,12 @@ void DistributedLagrangeProblem<dim, spacedim>::solve() {
         Aug_inv, C, Ct, invW, gamma};
 
     // Export matrix to Matlab
-    export_to_matlab_csv(augmented_block, "aug.csv");
+    if (parameters.use_operator_form)
+      export_to_matlab_csv(stiffness_matrix, "aug.csv");
+
     export_to_matlab_csv(coupling_matrix, "Ct.csv");
 
-    Vector<double> squares_export(mass_matrix.m());  // M^{2}\gamma
+    Vector<double> squares_export(mass_matrix.m()); // M^{2}\gamma
     for (types::global_dof_index i = 0; i < mass_matrix.m(); ++i)
       squares_export(i) =
           (mass_matrix.diag_element(i) * mass_matrix.diag_element(i)) /
@@ -916,7 +1018,7 @@ void DistributedLagrangeProblem<dim, spacedim>::export_results_to_csv_file() {
               ExcMessage("You must set the name of the parameter file."));
   std::filesystem::path p(parameters_filename);
   myfile.open(p.stem().string() + ".csv",
-              std::ios::app);  // get the filename and add proper extension
+              std::ios::app); // get the filename and add proper extension
   // myfile << "DoF (background + immersed)"
   //        << ","
   //        << "Iteration counts"
@@ -939,7 +1041,7 @@ void DistributedLagrangeProblem<dim, spacedim>::run() {
   output_results();
   export_results_to_csv_file();
 }
-}  // namespace ImmersedLaplaceSolver
+} // namespace ImmersedLaplaceSolver
 
 int main(int argc, char **argv) {
   try {

--- a/parameters/circle/Circle_parameters_f0_g1.prm
+++ b/parameters/circle/Circle_parameters_f0_g1.prm
@@ -1,9 +1,18 @@
 subsection Distributed Lagrange<1,2>
   set Coupling quadrature order                    = 3
-  set Initial embedded space refinement            = 12
-  set Initial embedding space refinement           = 11
+  set Initial embedded space refinement            = 11#12
+  set Initial embedding space refinement           = 10#11
   set Local refinements steps near embedded domain = 1
   set Solver                                       = augmented
+
+  subsection AL preconditioner
+    # Assemble the augmented (1,1)-block directly as a matrix. If false, the
+    # augmented (1,1)-block is applied as K + gamma * Ct * invW * C.
+    set Use operator version = true
+
+    # Use diagonal approximation for the inverse of W
+    set Use diagonal inverse = false
+  end
   subsection Embedded configuration
     set Function constants  = R=.2, Cx=.4, Cy=.4       
     set Function expression = R*cos(2*pi*x)+Cx; R*sin(2*pi*x)+Cy   

--- a/parameters_elliptic_interface/parameters_ideal.prm
+++ b/parameters_elliptic_interface/parameters_ideal.prm
@@ -8,7 +8,7 @@ set Export matrices for eigs-analysis  = false
 set FE degree background               = 1
 set FE degree immersed                 = 1
 set Homogeneous Dirichlet boundary ids = 0,1,2,3
-set Output directory                   = ./paper_data/ideal
+set Output directory                   = .
  # Using analytical solution for immersed circle (f = f_2 = 1)
 set Perform convergence study          = false
  # Check condition number of C*Ct after solve().
@@ -40,23 +40,26 @@ set Use diagonal inverse           = false
 #Use W = h^2 M in the AL preconditioner
 set Use h-scaled mass              = true
 
+#Directly assemble the augmented (1,1)-block
+set Use operator version           = false
+
    # Use the modified AL preconditioner. If false, the classical AL
    # preconditioner is used.
-set Use modified AL preconditioner = false
+set Use modified AL preconditioner = true
 
    # Use sqrt(2)-rule for gamma. It makes sense only for modified AL
    # variant.
 set Use sqrt(2)-rule for gamma     = false
 set Verbosity level                = 10
 set gamma fluid                    = 10 #gamma_AL_background
-set gamma solid                    = 10 #gamma_AL_immersed
+set gamma solid                    = 1e-2 #gamma_AL_immersed
   end
 
   subsection Grid generation
 set Background grid generator           = hyper_cube
 set Background grid generator arguments = -1.: 1: true
-set Immersed grid generator             = hyper_cube#hyper_ball#hyper_cube#hyper_ball#hyper_cube
-set Immersed grid generator arguments   = -0.14: 0.47: true#0.,0. : 0.3 : false#-0.14: 0.47: true#0.,0. : 0.22 : true#-0.14: 0.47: true
+set Immersed grid generator             = hyper_ball#hyper_cube#hyper_ball#hyper_cube#hyper_ball#hyper_cube
+set Immersed grid generator arguments   = 0.,0. : 0.3 : false#-0.14: 0.47: true#0.,0. : 0.3 : false#-0.14: 0.47: true#0.,0. : 0.22 : true#-0.14: 0.47: true
   end
 
   subsection Inner solver control
@@ -102,7 +105,7 @@ set Stop gamma      = 1
 set Initial background refinement = 4
 
    # Initial number of refinements used for the immersed domain Gamma.
-set Initial immersed refinement   = 2#0
+set Initial immersed refinement   = 0#2 if we use hyper_cube as immersed mesh
 
    # Number of refinement cycles to perform convergence studies.
 set Refinemented cycles           = 8

--- a/utilities.h
+++ b/utilities.h
@@ -13,6 +13,8 @@
 #include <deal.II/lac/utilities.h>
 #include <deal.II/lac/vector.h>
 #include <deal.II/numerics/matrix_tools.h>
+#include <deal.II/particles/particle_handler.h>
+#include <deal.II/particles/utilities.h>
 
 #include <algorithm>
 #include <cmath>
@@ -721,8 +723,9 @@ void build_AMG_augmented_block_scalar(
   augmented_block.add(gamma, BtWinvB);
 
   const FEValuesExtractors::Vector displacements(0);
-  std::vector<std::vector<bool>> constant_modes =
-      DoFTools::extract_constant_modes(space_dh, ComponentMask());
+  std::vector<std::vector<bool>> constant_modes;
+
+  DoFTools::extract_constant_modes(space_dh, ComponentMask(), constant_modes);
   TrilinosWrappers::PreconditionAMG::AdditionalData amg_data;
   // amg_data.constant_modes = constant_modes;
   amg_data.aggregation_threshold = 1e-3;
@@ -739,5 +742,99 @@ void build_AMG_augmented_block_scalar(
 // #endif
 #endif
 }
+
+/**
+ * Initialize the particle handler with particles at the quadrature points of
+ * the immersed domain. The particle handler is expected to be empty at this
+ * stage, and the function will throw an exception if this is not the case.
+ * This function will fill the particle handler object, and will allow to
+ * iterate through particles and query properties and background cells over
+ * which particles are falling.
+ *
+ */
+namespace ALUtils {
+template <int dim_back, int dim_immersed, int spacedim = dim_back>
+void initialize_particles(
+    Particles::ParticleHandler<spacedim> &solid_particle_handler,
+    const DoFHandler<dim_back, spacedim> &background_dh,
+    const DoFHandler<dim_immersed, spacedim> &immersed_dh,
+    const Mapping<spacedim> &background_mapping,
+    const Mapping<dim_immersed, spacedim> &immersed_mapping,
+    const QGauss<dim_immersed> &quadrature) {
+
+  Assert(solid_particle_handler.n_global_particles() == 0,
+         ExcMessage(
+             "The particle handler should be empty at this stage. Make sure "
+             "you don't call this function twice without clearing the "
+             "particles in between. Bailing out."));
+
+  std::vector<std::vector<BoundingBox<spacedim>>> global_fluid_bounding_boxes;
+
+  const Triangulation<dim_back, spacedim> &background_grid =
+      background_dh.get_triangulation();
+  const FiniteElement<spacedim> &space_fe = background_dh.get_fe();
+  const MPI_Comm &communicator = background_dh.get_mpi_communicator();
+
+  const Triangulation<dim_immersed, spacedim> &immersed_grid =
+      immersed_dh.get_triangulation();
+  const FiniteElement<dim_immersed, spacedim> &immersed_fe =
+      immersed_dh.get_fe();
+
+  std::vector<BoundingBox<spacedim>> all_boxes;
+  all_boxes.reserve(background_grid.n_active_cells());
+  for (const auto &cell : background_grid.active_cell_iterators())
+    if (cell->is_locally_owned())
+      all_boxes.emplace_back(cell->bounding_box());
+
+  const auto tree = pack_rtree(all_boxes);
+  // the extraction level is hardcoded here, but most of the times this is
+  // enough to get a crude approximation of the domain
+  const auto local_boxes = extract_rtree_level(tree, 1);
+
+  global_fluid_bounding_boxes =
+      Utilities::MPI::all_gather(communicator, local_boxes);
+
+  const unsigned int n_properties = 1;
+  solid_particle_handler.initialize(background_grid, background_mapping,
+                                    n_properties);
+
+  std::vector<Point<spacedim>> quadrature_points_vec;
+  quadrature_points_vec.reserve(quadrature.size() *
+                                immersed_grid.n_active_cells());
+
+  std::vector<std::vector<double>> properties;
+  properties.reserve(quadrature.size() * immersed_grid.n_active_cells());
+
+  FEValues<dim_immersed, spacedim> fe_v(
+      immersed_mapping, immersed_fe, quadrature,
+      update_JxW_values | update_quadrature_points);
+  for (const auto &cell : immersed_dh.active_cell_iterators())
+    if (cell->is_locally_owned()) {
+      fe_v.reinit(cell);
+      const auto &points = fe_v.get_quadrature_points();
+      const auto &JxW = fe_v.get_JxW_values();
+
+      for (unsigned int q = 0; q < points.size(); ++q) {
+        quadrature_points_vec.emplace_back(points[q]);
+        properties.emplace_back(std::vector<double>(n_properties, JxW[q]));
+      }
+    }
+
+  AssertThrow(!global_fluid_bounding_boxes.empty(),
+              ExcInternalError(
+                  "I was expecting the "
+                  "global_fluid_bounding_boxes to be filled at this stage. "
+                  "Make sure you fill this vector before trying to use it "
+                  "here. Bailing out."));
+
+  solid_particle_handler.insert_global_particles(
+      quadrature_points_vec, global_fluid_bounding_boxes, properties);
+
+#ifdef DEBUG
+  std::cout << "Solid particles: "
+            << solid_particle_handler.n_global_particles() << std::endl;
+#endif
+}
+} // namespace ALUtils
 
 #endif

--- a/utilities.h
+++ b/utilities.h
@@ -772,7 +772,6 @@ void initialize_particles(
 
   const Triangulation<dim_back, spacedim> &background_grid =
       background_dh.get_triangulation();
-  const FiniteElement<spacedim> &space_fe = background_dh.get_fe();
   const MPI_Comm &communicator = background_dh.get_mpi_communicator();
 
   const Triangulation<dim_immersed, spacedim> &immersed_grid =


### PR DESCRIPTION
This PR introduces an operator-like approach to discretize the continuous version of the augmented (1,1)-block in the AL preconditioner, as an alternative to the purely algebraic construction. The method exploits particles data structures to efficiently compute the contributions associated with the augmented term in the bilinear form, which require evaluating background basis functions at immersed quadrature points.

The parameter files have been updated to support the selection of both ideal and modified variants, including this operator-like implementation. Also the examples with a codim1 immersed domain has been adapted.

Overall, the addition is quite clean: particles are first initialized using the utility `ALUtils::initialize_particles()`, after which we loop over them to assemble the augmented contribution.

@luca-heltai, this approach behaves consistently in both codim-0 and codim-1 examples, yielding identical outer iteration counts and maintaining the robust behavior of the preconditioner. The only adjustment needed when switching between codim1 or codim0 configurations is the choice of scaling in the AL parameter, i.e., using either $h^{-1}$ or $h^{-2}$ as discussed.

```C++
    QGauss<dim> immersed_quadrature(parameters.immersed_quadrature_degree);
    ALUtils::initialize_particles<dim, dim, dim>(
        immersed_particle_handler, dof_handler_bg, dof_handler_fg,
        background_mapping, immersed_mapping,
        immersed_quadrature);

    // loop over the particles to build the AL term
    std::vector<types::global_dof_index> background_dof_indices(
        fe_bg.n_dofs_per_cell());

    FullMatrix<double> local_matrix(fe_bg.n_dofs_per_cell(),
                                    fe_bg.n_dofs_per_cell());

    auto particle = immersed_particle_handler.begin();
    while (particle != immersed_particle_handler.end()) {
      local_matrix = 0;
      const auto &cell = particle->get_surrounding_cell();
      const auto &dh_cell =
          typename DoFHandler<dim>::cell_iterator(*cell, &dof_handler_bg);
      dh_cell->get_dof_indices(background_dof_indices);

      const auto pic = immersed_particle_handler.particles_in_cell(cell);
      Assert(pic.begin() == particle, ExcInternalError());
      for (const auto &p : pic) {
        const Point<dim> ref_q = p.get_reference_location();
        const double JxW = p.get_properties()[0];

        for (unsigned int i = 0; i < fe_bg.n_dofs_per_cell(); ++i) {
          for (unsigned int j = 0; j < fe_bg.n_dofs_per_cell(); ++j) {
            local_matrix(i, j) += parameters.gamma_AL_background *
                                  fe_bg.shape_value(i, ref_q) *
                                  fe_bg.shape_value(j, ref_q) * JxW;
          }
        }
      }
      
      // add local new contributions to (1,1) block
      constraints_bg.distribute_local_to_global(
          local_matrix, background_dof_indices, augmented_block);

      particle = pic.end();
    }
```
