### PR TITLE
Allow 3D simplex meshes for Lagrange multiplier (boundary conditions)

### DIFF
--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -55,8 +55,8 @@
 #include <fstream>
 #include <iostream>
 
-#include <augmented_lagrangian_preconditioner.h>
-#include <utilities.h>
+#include "augmented_lagrangian_preconditioner.h"
+#include "utilities.h"
 
 namespace NitscheBCs {
 using namespace dealii;
@@ -146,6 +146,8 @@ public:
     // and use the hardcoded manufactured solution  u(x,y) = sin(pi x) sin(pi y)
     // on (0,1)^2,
     bool use_manufactured_solution = false;
+
+    bool iterative_inversion_mass_matrix = false;
 
     bool initialized = false;
   };
@@ -252,6 +254,11 @@ NitscheLagrangeProblem<dim, spacedim>::Parameters::Parameters()
       "If true, override the right-hand side and Dirichlet data with the "
       "hardcoded manufactured solution u = sin(pi x) sin(pi y) on the unit "
       "square, and report L2/H1 errors plus convergence rates.");
+  add_parameter(
+      "Iterative inversion mass matrix", iterative_inversion_mass_matrix,
+      "If true, invert the boundary mass matrix (used inside the Schur "
+      "preconditioner) iteratively with CG + Jacobi, instead of factorizing "
+      "it with UMFPACK.");
 
   parse_parameters_call_back.connect([&]() -> void { initialized = true; });
 }
@@ -703,10 +710,29 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
 
   // Zero (1,1) block: (multiplier,multiplier)
   const auto Zero = null_operator(Ct * C);
+
+  // Inversion of the boundary mass matrix M, used inside the Schur
+  // preconditioner. Two options:
+  //  - direct (UMFPACK),
+  //  - iterative (CG + Jacobi)
   SparseDirectUMFPACK M_inv_umfpack;
-  std::cout << "Factorizing mass matrix on multiplier space..." << std::endl;
-  M_inv_umfpack.initialize(boundary_mass_matrix);
-  std::cout << "Done." << std::endl;
+  PreconditionJacobi<SparseMatrix<double>> M_jacobi;
+  ReductionControl mass_solver_control(1000, 1.e-12, 1.e-10, false, false);
+  SolverCG<Vector<double>> mass_cg(mass_solver_control);
+  LinearOperator<Vector<double>, Vector<double>> invM;
+  if (parameters.iterative_inversion_mass_matrix) {
+    std::cout << "Setting up CG + Jacobi for the multiplier mass matrix..."
+              << std::endl;
+    M_jacobi.initialize(boundary_mass_matrix);
+    invM = inverse_operator(linear_operator(boundary_mass_matrix), mass_cg,
+                            M_jacobi);
+    std::cout << "Done." << std::endl;
+  } else {
+    std::cout << "Factorizing mass matrix on multiplier space..." << std::endl;
+    M_inv_umfpack.initialize(boundary_mass_matrix);
+    invM = linear_operator(boundary_mass_matrix, M_inv_umfpack);
+    std::cout << "Done." << std::endl;
+  }
 
   // Surface and bulk mappings are stored as members; reuse them here.
   const Mapping<dim, spacedim> &embedded_mapping = *surf_mapping;
@@ -809,7 +835,6 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
   SolverCG<Vector<double>> solver_lagrangian(inner_solver_control);
   auto A_inv = inverse_operator(Aug, solver_lagrangian,
                                 prec_for_cg); //! linear solver augmented
-  auto invM = linear_operator(boundary_mass_matrix, M_inv_umfpack);
   //  invW = (1/h) * M^{-1}, used both as the Schur preconditioner
   // (-gamma * invW) and to build the augmentation/RHS terms.
   auto invW = invW_scale * invM;
@@ -950,8 +975,8 @@ int main(int argc, char **argv) {
 
     Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-    constexpr unsigned int dim = 2;
-    constexpr unsigned int spacedim = 3;
+    constexpr unsigned int dim = 1;
+    constexpr unsigned int spacedim = 2;
 
     NitscheLagrangeProblem<dim, spacedim>::Parameters parameters;
     NitscheLagrangeProblem<dim, spacedim> problem(parameters);

--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -20,8 +20,11 @@
 
 #include <deal.II/dofs/dof_tools.h>
 
+#include <deal.II/fe/fe_dgq.h>
 #include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/fe_simplex_p.h>
 #include <deal.II/fe/fe_values.h>
+#include <deal.II/fe/mapping_fe.h>
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
@@ -57,6 +60,22 @@
 
 namespace NitscheBCs {
 using namespace dealii;
+
+// True if the parameter selects tensor-product (quad/hex) cells.
+inline bool is_hex_mesh(const std::string &mesh_type) {
+  return mesh_type == "hex";
+}
+
+// Build a quadrature appropriate for the active mesh type.
+// QGauss is implemented for any positive number of points; QGaussSimplex is
+// only implemented for n_points_1D in {1,2,3,4} so let's cap the quad rule.
+template <int d>
+inline Quadrature<d> make_quadrature(const std::string &mesh_type,
+                                     const unsigned int n) {
+  if (is_hex_mesh(mesh_type))
+    return QGauss<d>(std::max(1u, n));
+  return QGaussSimplex<d>(std::min(4u, std::max(1u, n)));
+}
 
 // Manufactured solution used for the optional convergence study.
 template <int spacedim> class ManufacturedSolution : public Function<spacedim> {
@@ -113,7 +132,9 @@ public:
     unsigned int verbosity_level = 4;
     bool use_discontinuous_multiplier = false;
     std::string name_external_grid = "idealized_lv.msh";
-    double scale_factor = 1;
+    double scale_factor = 1.0;
+    // Cell type for both the bulk and boundary meshes: "hex" or "simplex".
+    std::string mesh_type = "simplex";
 
     // If true, ignore the user-provided right-hand side and Dirichlet data
     // and use the hardcoded manufactured solution  u(x,y) = sin(pi x) sin(pi y)
@@ -138,11 +159,13 @@ private:
 
   Triangulation<spacedim> space_grid;
   std::unique_ptr<FiniteElement<spacedim>> space_fe;
+  std::unique_ptr<Mapping<spacedim>> bulk_mapping;
   DoFHandler<spacedim> space_dh;
 
   // Boundary (multiplier) mesh and FE, extracted from space_grid.
   std::unique_ptr<Triangulation<dim, spacedim>> boundary_grid;
   std::unique_ptr<FiniteElement<dim, spacedim>> multiplier_fe;
+  std::unique_ptr<Mapping<dim, spacedim>> surf_mapping;
   DoFHandler<dim, spacedim> boundary_dh;
 
   // Surface-cell -> bulk-face map filled by extract_boundary_mesh.
@@ -206,6 +229,11 @@ NitscheLagrangeProblem<dim, spacedim>::Parameters::Parameters()
   add_parameter("Scale factor for the external grid", scale_factor);
   add_parameter("Coupling quadrature order", coupling_quadrature_order);
   add_parameter("Verbosity level", verbosity_level);
+  add_parameter("Mesh type", mesh_type,
+                "Cell type used for both the bulk and boundary meshes. "
+                "Either \"hex\" (tensor-product quads/hexes) or \"simplex\" "
+                "(tris/tets).",
+                ParameterAcceptor::prm, Patterns::Selection("hex|simplex"));
   add_parameter(
       "Use manufactured solution", use_manufactured_solution,
       "If true, override the right-hand side and Dirichlet data with the "
@@ -263,9 +291,20 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
     space_grid.refine_global(extra_refinements);
     GridTools::scale(parameters.scale_factor, space_grid);
   } else {
-    GridGenerator::generate_from_name_and_arguments(
-        space_grid, parameters.name_of_grid, parameters.arguments_for_grid);
-    space_grid.refine_global(parameters.initial_refinement + extra_refinements);
+    if (is_hex_mesh(parameters.mesh_type)) {
+      GridGenerator::generate_from_name_and_arguments(
+          space_grid, parameters.name_of_grid, parameters.arguments_for_grid);
+      space_grid.refine_global(parameters.initial_refinement +
+                               extra_refinements);
+    } else {
+      // convert to simplex mesh so the rest of the program can run on
+      // tris/tets.
+      Triangulation<spacedim> hex_grid;
+      GridGenerator::generate_from_name_and_arguments(
+          hex_grid, parameters.name_of_grid, parameters.arguments_for_grid);
+      hex_grid.refine_global(parameters.initial_refinement + extra_refinements);
+      GridGenerator::convert_hypercube_to_simplex_mesh(hex_grid, space_grid);
+    }
   }
   ++extra_refinements;
 
@@ -275,16 +314,75 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
   face_to_bulk_cell.clear();
   surface_to_volume_map.clear();
 
-  // Extract the boundary mesh on the bulk grid: the returned map directly
-  // relates active surface cells to active bulk boundary faces, so no
-  // post-processing is needed.
+  // Extract the boundary mesh on the bulk grid. For hypercube meshes we use
+  // GridGenerator::extract_boundary_mesh, which already returns the surface
+  // cell -> bulk face map. That function is hardcoded for tensor-product
+  // cells (faces with 4 vertices in 3d) and does not support simplex bulk
+  // meshes, so for simplex grids we build the surface triangulation and
+  // associated map manually.
   boundary_grid = std::make_unique<Triangulation<dim, spacedim>>();
-  surface_to_volume_map =
-      GridGenerator::extract_boundary_mesh(space_grid, *boundary_grid);
+  if (is_hex_mesh(parameters.mesh_type)) {
+    surface_to_volume_map =
+        GridGenerator::extract_boundary_mesh(space_grid, *boundary_grid);
+  } else {
+    using BulkFaceIt =
+        typename Triangulation<spacedim, spacedim>::face_iterator;
 
-  // Bulk DoFs
-  space_fe = std::make_unique<FE_Q<spacedim>>(
-      parameters.bulk_space_finite_element_degree);
+    std::vector<Point<spacedim>> surf_vertices;
+    std::vector<CellData<dim>> surf_cells;
+    std::vector<BulkFaceIt> face_per_surf_cell;
+
+    std::map<unsigned int, unsigned int> bulk_to_surf_vertex;
+    for (const auto &bulk_cell : space_grid.active_cell_iterators())
+      for (const unsigned int f : bulk_cell->face_indices())
+        if (bulk_cell->at_boundary(f)) {
+          const auto face = bulk_cell->face(f);
+          const unsigned int n_v = face->n_vertices();
+          CellData<dim> cd;
+          cd.vertices.resize(n_v);
+          for (unsigned int j = 0; j < n_v; ++j) {
+            const unsigned int v_index = face->vertex_index(j);
+            auto it = bulk_to_surf_vertex.find(v_index);
+            if (it == bulk_to_surf_vertex.end()) {
+              const unsigned int new_index = surf_vertices.size();
+              surf_vertices.push_back(face->vertex(j));
+              bulk_to_surf_vertex[v_index] = new_index;
+              cd.vertices[j] = new_index;
+            } else {
+              cd.vertices[j] = it->second;
+            }
+          }
+          cd.material_id = static_cast<types::material_id>(face->boundary_id());
+          cd.manifold_id = face->manifold_id();
+          surf_cells.push_back(std::move(cd));
+          face_per_surf_cell.push_back(face);
+        }
+
+    AssertThrow(!surf_cells.empty(), ExcMessage("No boundary faces found"));
+
+    boundary_grid->create_triangulation(surf_vertices, surf_cells,
+                                        SubCellData());
+
+    // create_triangulation preserves the order of input cells, so the i-th
+    // active surface cell corresponds to the i-th boundary face we pushed.
+    unsigned int idx = 0;
+    for (const auto &surf_cell : boundary_grid->active_cell_iterators()) {
+      surface_to_volume_map[surf_cell] = face_per_surf_cell[idx];
+      ++idx;
+    }
+  }
+
+  // Bulk DoFs and bulk mapping
+  if (is_hex_mesh(parameters.mesh_type)) {
+    space_fe = std::make_unique<FE_Q<spacedim>>(
+        parameters.bulk_space_finite_element_degree);
+    bulk_mapping = std::make_unique<MappingQ1<spacedim>>();
+  } else {
+    space_fe = std::make_unique<FE_SimplexP<spacedim>>(
+        parameters.bulk_space_finite_element_degree);
+    bulk_mapping =
+        std::make_unique<MappingFE<spacedim>>(FE_SimplexP<spacedim>(1));
+  }
   space_dh.distribute_dofs(*space_fe);
 
   // boundary conditions are imposed weakly through lambda.
@@ -300,13 +398,25 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
   solution.reinit(space_dh.n_dofs());
   embedding_rhs.reinit(space_dh.n_dofs());
 
-  // Multiplier DoFs on the boundary mesh.
-  if (parameters.use_discontinuous_multiplier == true)
-    multiplier_fe = std::make_unique<FE_DGQ<dim, spacedim>>(
-        parameters.multiplier_finite_element_degree);
-  else // continuous
-    multiplier_fe = std::make_unique<FE_Q<dim, spacedim>>(
-        parameters.multiplier_finite_element_degree);
+  // Multiplier DoFs on the boundary mesh, plus surface mapping.
+  if (is_hex_mesh(parameters.mesh_type)) {
+    if (parameters.use_discontinuous_multiplier == true)
+      multiplier_fe = std::make_unique<FE_DGQ<dim, spacedim>>(
+          parameters.multiplier_finite_element_degree);
+    else // continuous
+      multiplier_fe = std::make_unique<FE_Q<dim, spacedim>>(
+          parameters.multiplier_finite_element_degree);
+    surf_mapping = std::make_unique<MappingQ1<dim, spacedim>>();
+  } else {
+    if (parameters.use_discontinuous_multiplier == true)
+      multiplier_fe = std::make_unique<FE_SimplexDGP<dim, spacedim>>(
+          parameters.multiplier_finite_element_degree);
+    else // continuous
+      multiplier_fe = std::make_unique<FE_SimplexP<dim, spacedim>>(
+          parameters.multiplier_finite_element_degree);
+    surf_mapping = std::make_unique<MappingFE<dim, spacedim>>(
+        FE_SimplexP<dim, spacedim>(1));
+  }
 
   boundary_dh.reinit(*boundary_grid);
   boundary_dh.distribute_dofs(*multiplier_fe);
@@ -366,8 +476,9 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
   TimerOutput::Scope timer_section(monitor, "Assemble system");
 
   {
-    const QGauss<spacedim> quadrature(2 * space_fe->degree + 1);
-    FEValues<spacedim> fe_values(*space_fe, quadrature,
+    const auto quadrature = make_quadrature<spacedim>(parameters.mesh_type,
+                                                      2 * space_fe->degree + 1);
+    FEValues<spacedim> fe_values(*bulk_mapping, *space_fe, quadrature,
                                  update_values | update_gradients |
                                      update_quadrature_points |
                                      update_JxW_values);
@@ -418,7 +529,7 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
   const unsigned int boundary_q =
       std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
                 parameters.coupling_quadrature_order});
-  const QGauss<dim> face_quad(boundary_q);
+  const auto face_quad = make_quadrature<dim>(parameters.mesh_type, boundary_q);
 
   // RHS for the multiplier equation
   ManufacturedDirichlet<spacedim> manufactured_g;
@@ -426,11 +537,12 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
       parameters.use_manufactured_solution
           ? static_cast<const Function<spacedim> &>(manufactured_g)
           : static_cast<const Function<spacedim> &>(g_function);
-  VectorTools::create_right_hand_side(boundary_dh, face_quad, g_for_rhs,
-                                      embedded_rhs);
+  VectorTools::create_right_hand_side(*surf_mapping, boundary_dh, face_quad,
+                                      g_for_rhs, embedded_rhs);
 
   // Mass matrix on the multiplier space (defined on boundary mesh).
-  MatrixTools::create_mass_matrix(boundary_dh, face_quad, boundary_mass_matrix);
+  MatrixTools::create_mass_matrix(*surf_mapping, boundary_dh, face_quad,
+                                  boundary_mass_matrix);
 
   // Assemble the coupling matrix C with entries C_{ij} = (phi_i^bulk,
   // phi_j^surf) integrated on the boundary face. pair each surface cell with
@@ -438,10 +550,10 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
   // coincide on the surface and on the bulk face.
 
   FEFaceValues<spacedim> fe_face_values(
-      *space_fe, face_quad,
+      *bulk_mapping, *space_fe, face_quad,
       update_values | update_quadrature_points | update_JxW_values);
-  FEValues<dim, spacedim> fe_surface_values(*multiplier_fe, face_quad,
-                                            update_values);
+  FEValues<dim, spacedim> fe_surface_values(*surf_mapping, *multiplier_fe,
+                                            face_quad, update_values);
 
   const unsigned int n_bulk_dofs = space_fe->n_dofs_per_cell();
   const unsigned int n_surf_dofs = multiplier_fe->n_dofs_per_cell();
@@ -524,7 +636,8 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
   SparseDirectUMFPACK M_inv_umfpack;
   M_inv_umfpack.initialize(boundary_mass_matrix);
 
-  MappingQ1<dim, spacedim> embedded_mapping; // TODO: do not hardcode this
+  // Surface and bulk mappings are stored as members; reuse them here.
+  const Mapping<dim, spacedim> &embedded_mapping = *surf_mapping;
   double gamma = 10.;
   TrilinosWrappers::PreconditionAMG amg_prec;
   auto prec_for_cg = null_operator(K);
@@ -540,11 +653,11 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
     const unsigned int boundary_q =
         std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
                   parameters.coupling_quadrature_order});
-    QGauss<dim> immersed_quadrature(boundary_q);
+    auto immersed_quadrature =
+        make_quadrature<dim>(parameters.mesh_type, boundary_q);
     ALUtils::initialize_particles<spacedim, dim, spacedim>(
-        immersed_particle_handler, space_dh, boundary_dh,
-        StaticMappingQ1<spacedim>::mapping, embedded_mapping,
-        immersed_quadrature);
+        immersed_particle_handler, space_dh, boundary_dh, *bulk_mapping,
+        embedded_mapping, immersed_quadrature);
 
     // and then we loop over the particles to build the AL term
     std::vector<types::global_dof_index> background_dof_indices(
@@ -606,10 +719,11 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
     const unsigned int boundary_q =
         std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
                   parameters.coupling_quadrature_order});
-    const QGauss<dim> face_quad(boundary_q);
+    const auto face_quad =
+        make_quadrature<dim>(parameters.mesh_type, boundary_q);
 
     FEFaceValues<spacedim> fe_face_values(
-        *space_fe, face_quad,
+        *bulk_mapping, *space_fe, face_quad,
         update_values | update_quadrature_points | update_JxW_values);
 
     const unsigned int n_bulk_dofs = space_fe->n_dofs_per_cell();
@@ -697,21 +811,25 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
 
   // If the manufactured solution is active, compute L2 / H1-seminorm errors
   // of u against u_ex on the bulk mesh
-  const double h_bulk = GridTools::maximal_cell_diameter(space_grid);
+  const double h_bulk =
+      GridTools::maximal_cell_diameter(space_grid, *bulk_mapping);
   convergence_table.add_value("h", h_bulk);
   if (parameters.use_manufactured_solution) {
     ManufacturedSolution<spacedim> u_ex;
-    const QGauss<spacedim> error_quad(2 * space_fe->degree + 2);
+    const auto error_quad = make_quadrature<spacedim>(parameters.mesh_type,
+                                                      2 * space_fe->degree + 2);
 
     Vector<double> per_cell_l2(space_grid.n_active_cells());
-    VectorTools::integrate_difference(space_dh, solution, u_ex, per_cell_l2,
-                                      error_quad, VectorTools::L2_norm);
+    VectorTools::integrate_difference(*bulk_mapping, space_dh, solution, u_ex,
+                                      per_cell_l2, error_quad,
+                                      VectorTools::L2_norm);
     const double l2_err = VectorTools::compute_global_error(
         space_grid, per_cell_l2, VectorTools::L2_norm);
 
     Vector<double> per_cell_h1(space_grid.n_active_cells());
-    VectorTools::integrate_difference(space_dh, solution, u_ex, per_cell_h1,
-                                      error_quad, VectorTools::H1_seminorm);
+    VectorTools::integrate_difference(*bulk_mapping, space_dh, solution, u_ex,
+                                      per_cell_h1, error_quad,
+                                      VectorTools::H1_seminorm);
     const double h1_err = VectorTools::compute_global_error(
         space_grid, per_cell_h1, VectorTools::H1_seminorm);
 
@@ -729,7 +847,8 @@ void NitscheLagrangeProblem<dim, spacedim>::output_results() {
   DataOut<spacedim> bulk_out;
   bulk_out.attach_dof_handler(space_dh);
   bulk_out.add_data_vector(solution, "u");
-  bulk_out.build_patches(parameters.bulk_space_finite_element_degree);
+  bulk_out.build_patches(*bulk_mapping,
+                         parameters.bulk_space_finite_element_degree);
   std::ofstream bulk_file("solution_bulk.vtu");
   bulk_out.write_vtu(bulk_file);
 
@@ -737,7 +856,7 @@ void NitscheLagrangeProblem<dim, spacedim>::output_results() {
   surf_out.attach_dof_handler(boundary_dh);
   surf_out.add_data_vector(lambda, "lambda",
                            DataOut<dim, spacedim>::type_dof_data);
-  surf_out.build_patches();
+  surf_out.build_patches(*surf_mapping);
   std::ofstream surf_file("multiplier.vtu");
   surf_out.write_vtu(surf_file);
 }

--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -25,6 +25,7 @@
 #include <deal.II/fe/mapping_q1.h>
 
 #include <deal.II/grid/grid_generator.h>
+#include <deal.II/grid/grid_in.h>
 #include <deal.II/grid/grid_tools.h>
 #include <deal.II/grid/tria.h>
 
@@ -111,6 +112,7 @@ public:
     unsigned int coupling_quadrature_order = 3;
     unsigned int verbosity_level = 4;
     bool use_discontinuous_multiplier = false;
+    std::string name_external_grid = "idealized_lv.msh";
 
     // If true, ignore the user-provided right-hand side and Dirichlet data
     // and use the hardcoded manufactured solution  u(x,y) = sin(pi x) sin(pi y)
@@ -199,6 +201,7 @@ NitscheLagrangeProblem<dim, spacedim>::Parameters::Parameters()
                 use_discontinuous_multiplier);
   add_parameter("Multiplier finite element degree",
                 multiplier_finite_element_degree);
+  add_parameter("Name of the external grid file", name_external_grid);
   add_parameter("Coupling quadrature order", coupling_quadrature_order);
   add_parameter("Verbosity level", verbosity_level);
   add_parameter(
@@ -248,9 +251,20 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
   // Rebuild the bulk grid from scratch each cycle
   static unsigned int extra_refinements = 0;
   space_grid.clear();
-  GridGenerator::generate_from_name_and_arguments(
-      space_grid, parameters.name_of_grid, parameters.arguments_for_grid);
-  space_grid.refine_global(parameters.initial_refinement + extra_refinements);
+
+  if (parameters.name_of_grid == "from_file") {
+    GridIn<spacedim> grid_in;
+    grid_in.attach_triangulation(space_grid);
+    std::ifstream input_file(parameters.name_external_grid);
+    AssertThrow(input_file, ExcMessage("Could not open grid file"));
+    grid_in.read_msh(input_file);
+    space_grid.refine_global(extra_refinements);
+    GridTools::scale(1e-3, space_grid);
+  } else {
+    GridGenerator::generate_from_name_and_arguments(
+        space_grid, parameters.name_of_grid, parameters.arguments_for_grid);
+    space_grid.refine_global(parameters.initial_refinement + extra_refinements);
+  }
   ++extra_refinements;
 
   stiffness_matrix.clear();
@@ -770,8 +784,8 @@ int main(int argc, char **argv) {
 
     Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
 
-    constexpr unsigned int dim = 1;
-    constexpr unsigned int spacedim = 2;
+    constexpr unsigned int dim = 2;
+    constexpr unsigned int spacedim = 3;
 
     NitscheLagrangeProblem<dim, spacedim>::Parameters parameters;
     NitscheLagrangeProblem<dim, spacedim> problem(parameters);

--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -55,8 +55,8 @@
 #include <fstream>
 #include <iostream>
 
-#include "augmented_lagrangian_preconditioner.h"
-#include "utilities.h"
+#include <augmented_lagrangian_preconditioner.h>
+#include <utilities.h>
 
 namespace NitscheBCs {
 using namespace dealii;
@@ -327,13 +327,14 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
   face_to_bulk_cell.clear();
   surface_to_volume_map.clear();
 
-  // Extract the boundary mesh on the bulk grid. For hypercube meshes we use
-  // GridGenerator::extract_boundary_mesh, which already returns the surface
-  // cell -> bulk face map. That function is hardcoded for tensor-product
-  // cells (faces with 4 vertices in 3d) and does not support simplex bulk
-  // meshes, so for simplex grids we build the surface triangulation and
-  // associated map manually.
+  // Extract the boundary mesh on the bulk grid. With newer deal.II versions,
+  // extract_boundary_mesh supports also simplex meshes
+
   boundary_grid = std::make_unique<Triangulation<dim, spacedim>>();
+#if DEAL_II_VERSION_GTE(9, 9, 0)
+  surface_to_volume_map =
+      GridGenerator::extract_boundary_mesh(space_grid, *boundary_grid);
+#else
   if (is_hex_mesh(parameters.mesh_type)) {
     surface_to_volume_map =
         GridGenerator::extract_boundary_mesh(space_grid, *boundary_grid);
@@ -384,6 +385,7 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
       ++idx;
     }
   }
+#endif
 
   // Bulk DoFs and bulk mapping
   if (is_hex_mesh(parameters.mesh_type)) {

--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -136,6 +136,12 @@ public:
     // Cell type for both the bulk and boundary meshes: "hex" or "simplex".
     std::string mesh_type = "simplex";
 
+    // If true, build the AL augmentation term gamma*(1/h)*(u,v)_{Gamma}
+    // by inserting tracking particles on the boundary and looping
+    // over them. If false, assemble the same term directly during the
+    // boundary-face loop used for the coupling matrix C.
+    bool use_particles_for_augmentation = true;
+
     // If true, ignore the user-provided right-hand side and Dirichlet data
     // and use the hardcoded manufactured solution  u(x,y) = sin(pi x) sin(pi y)
     // on (0,1)^2,
@@ -234,6 +240,13 @@ NitscheLagrangeProblem<dim, spacedim>::Parameters::Parameters()
                 "Either \"hex\" (tensor-product quads/hexes) or \"simplex\" "
                 "(tris/tets).",
                 ParameterAcceptor::prm, Patterns::Selection("hex|simplex"));
+  add_parameter(
+      "Use particles to impose constraints", use_particles_for_augmentation,
+      "If true, the AL augmentation term gamma*(1/h)*(u,v)_{Gamma} is "
+      "assembled via tracking particles placed at quadrature points on the "
+      "immersed boundary. If false, it is assembled directly through a "
+      "boundary-face loop on the bulk space, reusing the surface-to-bulk "
+      "face map already used to build the coupling matrix C.");
   add_parameter(
       "Use manufactured solution", use_manufactured_solution,
       "If true, override the right-hand side and Dirichlet data with the "
@@ -491,6 +504,33 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
     std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
     std::vector<double> rhs_values(n_q_points);
 
+    // When the augmentation is not done with particles, we add the
+    // gamma*(1/h)*(u,v)_{Gamma} term directly here while looping over
+    // bulk cells, by visiting their boundary faces. The constants below
+    // must match those used in solve() for the Schur preconditioner.
+
+    const bool augment_via_faces = !parameters.use_particles_for_augmentation;
+    const double gamma_aug = 10.0;
+    const double invW_scale_aug = augment_via_faces
+                                      ? 1.0 / GridTools::maximal_cell_diameter(
+                                                  *boundary_grid, *surf_mapping)
+                                      : 0.0;
+    const unsigned int boundary_q_aug =
+        std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
+                  parameters.coupling_quadrature_order});
+    const auto face_quad_aug =
+        make_quadrature<dim>(parameters.mesh_type, boundary_q_aug);
+    FEFaceValues<spacedim> fe_face_values_aug(
+        *bulk_mapping, *space_fe, face_quad_aug,
+        update_values | update_quadrature_points | update_JxW_values);
+    std::vector<double> g_values_aug(face_quad_aug.size());
+
+    ManufacturedDirichlet<spacedim> manufactured_g_aug;
+    const Function<spacedim> &g_for_aug =
+        parameters.use_manufactured_solution
+            ? static_cast<const Function<spacedim> &>(manufactured_g_aug)
+            : static_cast<const Function<spacedim> &>(g_function);
+
     for (const auto &cell : space_dh.active_cell_iterators()) {
       fe_values.reinit(cell);
       cell_matrix = 0.;
@@ -515,6 +555,33 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
                 JxW;
           cell_rhs(i) += fe_values.shape_value(i, q) * rhs_values[q] * JxW;
         }
+      }
+
+      // AL augmentation: add gamma*(1/h)*(u,v) on each boundary face of this
+      // cell directly into cell_matrix, and the consistent gamma*(1/h)*(g,v)
+      // contribution into cell_rhs.
+      if (augment_via_faces && cell->at_boundary()) {
+        for (const unsigned int f : cell->face_indices())
+          if (cell->face(f)->at_boundary()) {
+            fe_face_values_aug.reinit(cell, f);
+            g_for_aug.value_list(fe_face_values_aug.get_quadrature_points(),
+                                 g_values_aug);
+            for (unsigned int q = 0; q < face_quad_aug.size(); ++q) {
+              const double JxW = fe_face_values_aug.JxW(q);
+              const double gq = g_values_aug[q];
+              for (unsigned int i = 0; i < dofs_per_cell; ++i) {
+                const double v_i = fe_face_values_aug.shape_value(i, q);
+                cell_rhs(i) += gamma_aug * invW_scale_aug * v_i * gq * JxW;
+                for (unsigned int j = 0; j < dofs_per_cell; ++j)
+                  cell_matrix(i, j) +=
+                      gamma_aug *                          // gamma
+                      invW_scale_aug *                     // h^{-1}
+                      v_i *                                // phi_i
+                      fe_face_values_aug.shape_value(j, q) // phi_j
+                      * JxW;
+              }
+            }
+          }
       }
 
       cell->get_dof_indices(local_dof_indices);
@@ -616,6 +683,7 @@ void NitscheLagrangeProblem<dim, spacedim>::assemble_system() {
                            "measure: assembly is likely incorrect."));
   }
 #endif
+  std::cout << "Assembly complete." << std::endl;
 }
 
 template <int dim, int spacedim>
@@ -634,7 +702,9 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
   // Zero (1,1) block: (multiplier,multiplier)
   const auto Zero = null_operator(Ct * C);
   SparseDirectUMFPACK M_inv_umfpack;
+  std::cout << "Factorizing mass matrix on multiplier space..." << std::endl;
   M_inv_umfpack.initialize(boundary_mass_matrix);
+  std::cout << "Done." << std::endl;
 
   // Surface and bulk mappings are stored as members; reuse them here.
   const Mapping<dim, spacedim> &embedded_mapping = *surf_mapping;
@@ -648,56 +718,78 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
         GridTools::maximal_cell_diameter(*boundary_grid, embedded_mapping);
     invW_scale = 1.0 / h_immersed;
 
-    Particles::ParticleHandler<spacedim> immersed_particle_handler;
+    if (parameters.use_particles_for_augmentation) {
+      Particles::ParticleHandler<spacedim> immersed_particle_handler;
 
-    const unsigned int boundary_q =
-        std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
-                  parameters.coupling_quadrature_order});
-    auto immersed_quadrature =
-        make_quadrature<dim>(parameters.mesh_type, boundary_q);
-    ALUtils::initialize_particles<spacedim, dim, spacedim>(
-        immersed_particle_handler, space_dh, boundary_dh, *bulk_mapping,
-        embedded_mapping, immersed_quadrature);
+      const unsigned int boundary_q =
+          std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
+                    parameters.coupling_quadrature_order});
+      auto immersed_quadrature =
+          make_quadrature<dim>(parameters.mesh_type, boundary_q);
+      ALUtils::initialize_particles<spacedim, dim, spacedim>(
+          immersed_particle_handler, space_dh, boundary_dh, *bulk_mapping,
+          embedded_mapping, immersed_quadrature);
 
-    // and then we loop over the particles to build the AL term
-    std::vector<types::global_dof_index> background_dof_indices(
-        space_fe->n_dofs_per_cell());
+      // Assemble:
+      // gamma*(1/h)*(u,v)_{Gamma} into the (0,0) block of the augmented matrix,
+      // and the consistent gamma*(1/h)*(g,v)_{Gamma} contribution into the bulk
+      // rhs
+      ManufacturedDirichlet<spacedim> manufactured_g;
+      const Function<spacedim> &g_for_aug =
+          parameters.use_manufactured_solution
+              ? static_cast<const Function<spacedim> &>(manufactured_g)
+              : static_cast<const Function<spacedim> &>(g_function);
 
-    FullMatrix<double> local_matrix(space_fe->n_dofs_per_cell(),
-                                    space_fe->n_dofs_per_cell());
+      std::vector<types::global_dof_index> background_dof_indices(
+          space_fe->n_dofs_per_cell());
 
-    auto particle = immersed_particle_handler.begin();
-    while (particle != immersed_particle_handler.end()) {
-      local_matrix = 0;
-      const auto &cell = particle->get_surrounding_cell();
-      const auto &dh_cell =
-          typename DoFHandler<spacedim>::cell_iterator(*cell, &space_dh);
-      dh_cell->get_dof_indices(background_dof_indices); // background dofs
+      FullMatrix<double> local_matrix(space_fe->n_dofs_per_cell(),
+                                      space_fe->n_dofs_per_cell());
+      Vector<double> local_rhs(space_fe->n_dofs_per_cell());
 
-      const auto pic = immersed_particle_handler.particles_in_cell(cell);
-      Assert(pic.begin() == particle, ExcInternalError());
-      for (const auto &p : pic) {
-        const Point<spacedim> ref_q = p.get_reference_location();
-        const double JxW = p.get_properties()[0];
+      auto particle = immersed_particle_handler.begin();
+      while (particle != immersed_particle_handler.end()) {
+        local_matrix = 0;
+        local_rhs = 0;
+        const auto &cell = particle->get_surrounding_cell();
+        const auto &dh_cell =
+            typename DoFHandler<spacedim>::cell_iterator(*cell, &space_dh);
+        dh_cell->get_dof_indices(background_dof_indices); // background dofs
 
-        for (unsigned int i = 0; i < space_fe->n_dofs_per_cell(); ++i) {
-          for (unsigned int j = 0; j < space_fe->n_dofs_per_cell(); ++j) {
-            local_matrix(i, j) += gamma * invW_scale * // gamma * (1/h)
-                                  space_fe->shape_value(i, ref_q) * // phi_i(q)
-                                  space_fe->shape_value(j, ref_q) *
-                                  JxW; // phi_j(q)
+        const auto pic = immersed_particle_handler.particles_in_cell(cell);
+        Assert(pic.begin() == particle, ExcInternalError());
+        for (const auto &p : pic) {
+          const Point<spacedim> ref_q = p.get_reference_location();
+          const double JxW = p.get_properties()[0];
+          const double gq = g_for_aug.value(p.get_location());
+
+          for (unsigned int i = 0; i < space_fe->n_dofs_per_cell(); ++i) {
+            const double v_i = space_fe->shape_value(i, ref_q);
+            local_rhs(i) += gamma * invW_scale * v_i * gq * JxW;
+            for (unsigned int j = 0; j < space_fe->n_dofs_per_cell(); ++j) {
+              local_matrix(i, j) += gamma * invW_scale * // gamma * (1/h)
+                                    v_i * space_fe->shape_value(j, ref_q) * JxW;
+            }
           }
         }
+
+        constraints.distribute_local_to_global(
+            local_matrix, background_dof_indices, stiffness_matrix);
+        constraints.distribute_local_to_global(
+            local_rhs, background_dof_indices, embedding_rhs);
+
+        particle = pic.end();
       }
-
-      constraints.distribute_local_to_global(
-          local_matrix, background_dof_indices, stiffness_matrix);
-
-      particle = pic.end();
     }
 
+    // When use_particles_for_augmentation is false, the augmentation has
+    // already been added to stiffness_matrix during assemble_system().
+    std::cout
+        << "Building AMG preconditioner for the augmented stiffness matrix..."
+        << std::endl;
     amg_prec.initialize(stiffness_matrix);
     prec_for_cg = linear_operator(stiffness_matrix, amg_prec);
+    std::cout << "Done." << std::endl;
   }
 
   auto Aug = linear_operator(stiffness_matrix);
@@ -711,55 +803,6 @@ void NitscheLagrangeProblem<dim, spacedim>::solve() {
 
   system_rhs_block.block(0) = embedding_rhs;
   system_rhs_block.block(1) = embedded_rhs;
-
-  // Consistent RHS augmentation.
-  // We assemble it directly via a boundary-face loop on the bulk space (same
-  // pattern used for C), evaluating g at the same quadrature points.
-  {
-    const unsigned int boundary_q =
-        std::max({2u * space_fe->degree + 1u, 2u * multiplier_fe->degree + 1u,
-                  parameters.coupling_quadrature_order});
-    const auto face_quad =
-        make_quadrature<dim>(parameters.mesh_type, boundary_q);
-
-    FEFaceValues<spacedim> fe_face_values(
-        *bulk_mapping, *space_fe, face_quad,
-        update_values | update_quadrature_points | update_JxW_values);
-
-    const unsigned int n_bulk_dofs = space_fe->n_dofs_per_cell();
-    Vector<double> local_rhs(n_bulk_dofs);
-    std::vector<types::global_dof_index> bulk_dof_indices(n_bulk_dofs);
-    std::vector<double> g_values(face_quad.size());
-
-    ManufacturedDirichlet<spacedim> manufactured_g;
-    const Function<spacedim> &g_for_rhs =
-        parameters.use_manufactured_solution
-            ? static_cast<const Function<spacedim> &>(manufactured_g)
-            : static_cast<const Function<spacedim> &>(g_function);
-
-    for (const auto &surface_cell : boundary_dh.active_cell_iterators()) {
-      const auto bulk_face = surface_to_volume_map.at(surface_cell);
-      const auto &owner = face_to_bulk_cell.at(bulk_face);
-      const auto &bulk_cell = owner.first;
-      const unsigned int bulk_face_no = owner.second;
-
-      fe_face_values.reinit(bulk_cell, bulk_face_no);
-      g_for_rhs.value_list(fe_face_values.get_quadrature_points(), g_values);
-
-      local_rhs = 0;
-      for (unsigned int q = 0; q < face_quad.size(); ++q) {
-        const double JxW = fe_face_values.JxW(q);
-        const double gq = g_values[q];
-        for (unsigned int i = 0; i < n_bulk_dofs; ++i)
-          local_rhs(i) +=
-              gamma * invW_scale * fe_face_values.shape_value(i, q) * gq * JxW;
-      }
-
-      bulk_cell->get_dof_indices(bulk_dof_indices);
-      constraints.distribute_local_to_global(local_rhs, bulk_dof_indices,
-                                             system_rhs_block.block(0));
-    }
-  }
 
   SolverCG<Vector<double>> solver_lagrangian(inner_solver_control);
   auto A_inv = inverse_operator(Aug, solver_lagrangian,

--- a/nitsche_bcs.cc
+++ b/nitsche_bcs.cc
@@ -113,6 +113,7 @@ public:
     unsigned int verbosity_level = 4;
     bool use_discontinuous_multiplier = false;
     std::string name_external_grid = "idealized_lv.msh";
+    double scale_factor = 1;
 
     // If true, ignore the user-provided right-hand side and Dirichlet data
     // and use the hardcoded manufactured solution  u(x,y) = sin(pi x) sin(pi y)
@@ -202,6 +203,7 @@ NitscheLagrangeProblem<dim, spacedim>::Parameters::Parameters()
   add_parameter("Multiplier finite element degree",
                 multiplier_finite_element_degree);
   add_parameter("Name of the external grid file", name_external_grid);
+  add_parameter("Scale factor for the external grid", scale_factor);
   add_parameter("Coupling quadrature order", coupling_quadrature_order);
   add_parameter("Verbosity level", verbosity_level);
   add_parameter(
@@ -259,7 +261,7 @@ void NitscheLagrangeProblem<dim, spacedim>::setup_grids_and_dofs() {
     AssertThrow(input_file, ExcMessage("Could not open grid file"));
     grid_in.read_msh(input_file);
     space_grid.refine_global(extra_refinements);
-    GridTools::scale(1e-3, space_grid);
+    GridTools::scale(parameters.scale_factor, space_grid);
   } else {
     GridGenerator::generate_from_name_and_arguments(
         space_grid, parameters.name_of_grid, parameters.arguments_for_grid);

--- a/parameters_nitsche.prm
+++ b/parameters_nitsche.prm
@@ -1,14 +1,15 @@
 # Listing of Parameters
 # ---------------------
-subsection Nitsche Lagrange<1,2>
+subsection Nitsche Lagrange<2,3>
   set Coupling quadrature order             = 3
-  set Initial space refinement              = 3
+  set Initial space refinement              = 0
   set Bulk space finite element degree      = 1
   set Use discontinuous multiplier space    = true
-  set Multiplier finite element degree      = 0 #0
-  set Name of the grid                      = hyper_cube #hyper_ball
+  set Multiplier finite element degree      = 0 #1
+  set Name of the grid                      = from_file #hyper_ball
   set Arguments for the grid                = 0 : 1.: false #0.0, 0.0 : 1.0 : true
-  set Number of refinement cycles           = 5
+  set Name of the external grid file        = idealized_lv.msh
+  set Number of refinement cycles           = 3
   set Verbosity level                       = 4
   set Use manufactured solution             = false
 
@@ -22,10 +23,10 @@ subsection Nitsche Lagrange<1,2>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = x^2+y^2 #if(x>0.5, -1, 1) #sin(x)+y #0.
+    set Function expression = 10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
 
     # Names of the independent variables, separated by commas.
-    set Variable names      = x,y,t
+    set Variable names      = x,y,z,t
   end
 
   subsection Inner solver control
@@ -55,7 +56,7 @@ subsection Nitsche Lagrange<1,2>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = 1.     # default: 0
+    set Function expression = 10.     # default: 0
 
     # Names of the independent variables, separated by commas.
     set Variable names      = x,y,t

--- a/parameters_nitsche.prm
+++ b/parameters_nitsche.prm
@@ -1,21 +1,22 @@
 # Listing of Parameters
 # ---------------------
-subsection Nitsche Lagrange<2,3>
+# subsection Nitsche Lagrange<2,3>
+subsection Nitsche Lagrange<1,2>
   set Coupling quadrature order             = 3
-  set Initial space refinement              = 0
+  set Initial space refinement              = 4
   set Bulk space finite element degree      = 1
-  set Use discontinuous multiplier space    = true
+  set Use discontinuous multiplier space    = true #true
   set Multiplier finite element degree      = 0
   set Name of the grid                      = hyper_cube #from_file #hyper_ball
   set Arguments for the grid                = 0 : 1.: false #0.0, 0.0 : 1.0 : true
-  set Name of the external grid file        = #homer.msh #nefertiti.msh #cow.msh #happy_buddha.msh #beetle.msh #stanford-bunny.msh #popcorn3D.msh #horse.msh #idealized_lv.msh
-  set Scale factor for the external grid    = 1. #1e-2 #1e-3
-  set Number of refinement cycles           = 8
+  set Name of the external grid file        = lucy.msh #lion.msh #homer.msh #stanford-bunny.msh #nefertiti.msh #cow.msh #happy_buddha.msh #beetle.msh #popcorn3D.msh #horse.msh #idealized_lv.msh
+  set Scale factor for the external grid    = 1 #1e-2 #1e-3
+  set Number of refinement cycles           = 6
   set Verbosity level                       = 4
   set Mesh type                             = hex # hex | simplex
   set Use particles to impose constraints   = false
   set Use manufactured solution             = false
-
+  set Iterative inversion mass matrix       = false
 
   subsection Dirichlet boundary data
     # Symbolic constants for the function expression, in the form
@@ -26,10 +27,10 @@ subsection Nitsche Lagrange<2,3>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = x+y+z #10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
+    set Function expression = x+y #10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
 
     # Names of the independent variables, separated by commas.
-    set Variable names      = x,y,z,t
+    set Variable names      = x,y,t
   end
 
   subsection Inner solver control

--- a/parameters_nitsche.prm
+++ b/parameters_nitsche.prm
@@ -6,13 +6,14 @@ subsection Nitsche Lagrange<2,3>
   set Bulk space finite element degree      = 1
   set Use discontinuous multiplier space    = true
   set Multiplier finite element degree      = 0
-  set Name of the grid                      = hyper_cube #from_file # #hyper_ball
+  set Name of the grid                      = hyper_cube #from_file #hyper_ball
   set Arguments for the grid                = 0 : 1.: false #0.0, 0.0 : 1.0 : true
-  set Name of the external grid file        = horse.msh#stanford-bunny.msh #homer.msh #popcorn3D.msh #idealized_lv.msh
-  set Scale factor for the external grid    = 100. #1e-3
-  set Number of refinement cycles           = 6
+  set Name of the external grid file        = #homer.msh #nefertiti.msh #cow.msh #happy_buddha.msh #beetle.msh #stanford-bunny.msh #popcorn3D.msh #horse.msh #idealized_lv.msh
+  set Scale factor for the external grid    = 1. #1e-2 #1e-3
+  set Number of refinement cycles           = 8
   set Verbosity level                       = 4
   set Mesh type                             = hex # hex | simplex
+  set Use particles to impose constraints   = false
   set Use manufactured solution             = false
 
 
@@ -25,7 +26,7 @@ subsection Nitsche Lagrange<2,3>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = x+y #10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
+    set Function expression = x+y+z #10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
 
     # Names of the independent variables, separated by commas.
     set Variable names      = x,y,z,t

--- a/parameters_nitsche.prm
+++ b/parameters_nitsche.prm
@@ -5,13 +5,14 @@ subsection Nitsche Lagrange<2,3>
   set Initial space refinement              = 0
   set Bulk space finite element degree      = 1
   set Use discontinuous multiplier space    = true
-  set Multiplier finite element degree      = 0 #1
-  set Name of the grid                      = from_file #hyper_ball
+  set Multiplier finite element degree      = 0
+  set Name of the grid                      = hyper_cube #from_file # #hyper_ball
   set Arguments for the grid                = 0 : 1.: false #0.0, 0.0 : 1.0 : true
-  set Name of the external grid file        = idealized_lv.msh
-  set Scale factor for the external grid    = 1e-3
-  set Number of refinement cycles           = 3
+  set Name of the external grid file        = horse.msh#stanford-bunny.msh #homer.msh #popcorn3D.msh #idealized_lv.msh
+  set Scale factor for the external grid    = 100. #1e-3
+  set Number of refinement cycles           = 6
   set Verbosity level                       = 4
+  set Mesh type                             = hex # hex | simplex
   set Use manufactured solution             = false
 
 
@@ -24,7 +25,7 @@ subsection Nitsche Lagrange<2,3>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = 10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
+    set Function expression = x+y #10*(x + y) #x+y #0 #if(x>0.5, -1, 1) #sin(x)+y #0.
 
     # Names of the independent variables, separated by commas.
     set Variable names      = x,y,z,t
@@ -57,7 +58,7 @@ subsection Nitsche Lagrange<2,3>
     # Semicolon-separated formulas for the function components. Supports
     # standard operations, functions `sin`, `cos`, etc., and conditionals
     # `if(x>0, 1, -1)`.
-    set Function expression = 10.     # default: 0
+    set Function expression = 1.     # default: 0
 
     # Names of the independent variables, separated by commas.
     set Variable names      = x,y,t

--- a/parameters_nitsche.prm
+++ b/parameters_nitsche.prm
@@ -9,6 +9,7 @@ subsection Nitsche Lagrange<2,3>
   set Name of the grid                      = from_file #hyper_ball
   set Arguments for the grid                = 0 : 1.: false #0.0, 0.0 : 1.0 : true
   set Name of the external grid file        = idealized_lv.msh
+  set Scale factor for the external grid    = 1e-3
   set Number of refinement cycles           = 3
   set Verbosity level                       = 4
   set Use manufactured solution             = false

--- a/utilities.h
+++ b/utilities.h
@@ -760,7 +760,7 @@ void initialize_particles(
     const DoFHandler<dim_immersed, spacedim> &immersed_dh,
     const Mapping<spacedim> &background_mapping,
     const Mapping<dim_immersed, spacedim> &immersed_mapping,
-    const QGauss<dim_immersed> &quadrature) {
+    const Quadrature<dim_immersed> &quadrature) {
 
   Assert(solid_particle_handler.n_global_particles() == 0,
          ExcMessage(


### PR DESCRIPTION
This PR introduces several enhancements to broaden the applicability of the code and improve preconditioning performance:

- Extends support to simplex meshes
- Enables the import of 3D external simplex meshes
- Improves the assembly of terms associated with the augmented Lagrangian preconditioner

At present, the extraction of boundary meshes for 3D simplex elements is not directly supported in deal.II. As a temporary workaround, a hard-coded implementation is introduced here. This will be removed once the corresponding upstream functionality becomes available.

These changes are motivated by the need to evaluate the robustness of the preconditioner on more complex geometries. For instance, those generated from .obj files and subsequently meshed using fTetWild, such as the classical stanford bunny

<img width="806" height="738" alt="image" src="https://github.com/user-attachments/assets/81da7949-0ce6-462a-8d05-fa79940385d3" />



